### PR TITLE
Sahar/branch op support

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -34,9 +34,9 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
     : global_context_(global_context), subgraph_context_(subgraph_context) {
 
   ie_cnn_network_ = CreateCNNNetwork(model_proto, subgraph_context_.device_id, subgraph_context_.precision);
-  if(subgraph_context_.device_id == "CPU"){
-    SetIODefs(model_proto, ie_cnn_network_);
-  }
+  //if(subgraph_context_.device_id == "CPU"){
+  SetIODefs(model_proto, ie_cnn_network_);
+  //}
   InferenceEngine::ExecutableNetwork exe_network;
 
   // Loading model to the plugin

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -34,9 +34,7 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
     : global_context_(global_context), subgraph_context_(subgraph_context) {
 
   ie_cnn_network_ = CreateCNNNetwork(model_proto, subgraph_context_.device_id, subgraph_context_.precision);
-  //if(subgraph_context_.device_id == "CPU"){
   SetIODefs(model_proto, ie_cnn_network_);
-  //}
   InferenceEngine::ExecutableNetwork exe_network;
 
   // Loading model to the plugin

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -125,6 +125,7 @@ bool IsOpSupported(std::string name, std::string device) {
       "Relu",
       "Reshape",
       "Shape",
+      "Selu",
       "Sigmoid",
       "Slice",
       "Softmax",
@@ -134,6 +135,7 @@ bool IsOpSupported(std::string name, std::string device) {
       "Sum",
       "Tanh",
       "TopK",
+      "Erf",
       "Transpose",
       "Unsqueeze",
   };
@@ -150,12 +152,10 @@ bool IsOpSupported(std::string name, std::string device) {
     "Atanh",
     "Cos",
     "Cosh",
-    "Erf",
     "HardSigmoid",
     "ReduceLogSum",
     "ReduceProd",
     "ReduceSumSquare",
-    "Selu",
     "Sign",
     "Sinh",
     "Softsign",
@@ -169,17 +169,13 @@ bool IsOpSupported(std::string name, std::string device) {
     "Asin",
     "Asinh",
     "Atan",
-    "Erf",
     "HardSigmoid",
-    "Selu",
     "Tan",
   };
   std::set<std::string> supported_ops_vpu = {
-    "Erf",
     "ReduceLogSum",
     "ReduceProd",
     "ReduceSumSquare",
-    "Selu",
     "SinFloat",
   };
 

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -97,6 +97,7 @@ bool IsOpSupported(std::string name, std::string device) {
       "Div",
       "Dropout",
       "Elu",
+      "Erf",
       "Flatten",
       "Floor",
       "Gather",
@@ -124,8 +125,8 @@ bool IsOpSupported(std::string name, std::string device) {
       "ReduceSum",
       "Relu",
       "Reshape",
-      "Shape",
       "Selu",
+      "Shape",
       "Sigmoid",
       "Slice",
       "Softmax",
@@ -135,7 +136,6 @@ bool IsOpSupported(std::string name, std::string device) {
       "Sum",
       "Tanh",
       "TopK",
-      "Erf",
       "Transpose",
       "Unsqueeze",
   };
@@ -164,7 +164,6 @@ bool IsOpSupported(std::string name, std::string device) {
 
 
   std::set<std::string> supported_ops_gpu = {
-    "HardSigmoid",
     "Abs",
     "Asin",
     "Asinh",
@@ -422,11 +421,10 @@ static bool IsUnsupportedOpMode(const Node* node, const onnxruntime::GraphViewer
     // nGraph only supports constant shape input values
     const auto& shape_input = node->InputDefs()[1];
     return !graph_viewer.IsConstantInitializer(shape_input->Name(), true);
-  } else if (optype == "ArgMax" || optype == "ArgMin" ) {
-      
+  } else if (optype == "ArgMax" || optype == "ArgMin") {
+    // tensor type supports float as input for argmax and argmin  
     auto dtype = node->InputDefs()[0]->TypeAsProto()->tensor_type().elem_type();
-    if (!(dtype == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT ||
-          dtype == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BFLOAT16)) {
+    if (dtype != ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT) {
       return true;      
     }
   }  


### PR DESCRIPTION
pulling in changes for argmax and argmin ops which only support fp32 and bf16 for first input

-It solves the test failures where int32 was the first input and was unsupported by openvino 
-also adds supported ops for gpu and vpu and sets the io precision for gpu and vpu 