### PR TITLE
Sahar/csharp support openvino

### DIFF
--- a/csharp/OnnxRuntime.CSharp.proj
+++ b/csharp/OnnxRuntime.CSharp.proj
@@ -16,6 +16,7 @@ CMake creates a target to this project
     <NugetExe Condition= " '$(NugetExe)' == '' ">nuget</NugetExe>
     <TargetArchitecture Condition=" '$(TargetArchitecture)' == '' ">x64</TargetArchitecture>
     <IsReleaseBuild Condition=" '$(IsReleaseBuild)' == '' ">false</IsReleaseBuild>
+	<IsLinuxBuild Condition=" '$(IsLinuxBuild)' == '' ">libonnxruntime.so</IsLinuxBuild>
 
     <!--internal build related properties-->
     <OnnxRuntimeSourceDirectory Condition="'$(OnnxRuntimeSourceDirectory)'==''">..</OnnxRuntimeSourceDirectory>
@@ -111,7 +112,7 @@ CMake creates a target to this project
              Properties="NoBuild=true;Platform=AnyCPU;PackageVersion=$(PackageVersion);OrtPackageId=$(OrtPackageId)"/>
     
     <Message Importance="High" Text="Generating nuspec for the native Nuget package ..." />
-    <Exec ContinueOnError="False" Command="python ..\tools\nuget\generate_nuspec_for_native_nuget.py --package_version $(PackageVersion) --package_name $(OrtPackageId) --target_architecture $(TargetArchitecture) --build_config $(Configuration) --native_build_path $(NativeBuildOutputDirAbs) --packages_path $(OnnxRuntimePackagesDirectoryAbs) --ort_build_path $(OnnxRuntimeBuildDirectoryAbs) --sources_path $(OnnxRuntimeSourceDirectoryAbs) --commit_id $(GitCommitHash) --is_release_build $(IsReleaseBuild)" ConsoleToMSBuild="true">
+    <Exec ContinueOnError="False" Command="python ..\tools\nuget\generate_nuspec_for_native_nuget.py --package_version $(PackageVersion) --package_name $(OrtPackageId) --target_architecture $(TargetArchitecture) --build_config $(Configuration) --native_build_path $(NativeBuildOutputDirAbs) --packages_path $(OnnxRuntimePackagesDirectoryAbs) --ort_build_path $(OnnxRuntimeBuildDirectoryAbs) --sources_path $(OnnxRuntimeSourceDirectoryAbs) --commit_id $(GitCommitHash) --is_release_build $(IsReleaseBuild) --linux_build $(IsLinuxBuild)" ConsoleToMSBuild="true">
         <Output TaskParameter="ConsoleOutput" PropertyName="GenerateNuspecOutput" />
     </Exec>
 

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -156,13 +156,12 @@ We currently do not have a process to build directly in Linux. But we can
 copy shared library libonnxruntime.so to onnxruntime repository in windows
 and execute the same commands above to get custom nuget package for linux 
 
-On Linux Server
+On Linux Machine
 ```
 ./build.sh --config Debug --build_shared_lib --use_openvino $Device 
 ```
 
-On Windows Server
-
+On Windows Machine
 ```
 cp libonnxruntime.so $PATH/onnxruntime/ 
 .\build.bat --config Debug --build --use_openvino $Device --build_csharp

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -137,3 +137,32 @@ Below topologies from ONNX open model zoo are fully supported on OpenVINO Execut
 | tiny_yolov2 | Yes | Yes | Yes | Yes* |
 
 *FPGA only runs in HETERO mode wherein the layers that are not supported on FPGA fall back to OpenVINO CPU.
+
+## CSharp API
+
+*To use csharp api for openvino execution provider create a custom nuget package.
+
+#Windows
+
+Build windows build with --build_csharp option. 
+.\build.bat --config Debug --build --use_openvino $Device --build_csharp
+
+Build Custom Nuget Package
+msbuild csharp\OnnxRuntime.CSharp.proj /p:Configuration=Debug /t:CreatePackage
+
+#Linux
+We do not have a current build process to build directly in Linux. But we can
+copy shared library libonnxruntime.so to onnxruntime repository in windows
+and execute the same commands above to get custom nuget package with linux shared library 
+
+Build windows build with --build_csharp option.
+.\build.bat --config Debug --build --use_openvino $Device --build_csharp
+
+Build Custom Nuget Package
+msbuild csharp\OnnxRuntime.CSharp.proj /p:Configuration=Debug /t:CreatePackage
+
+
+ 
+
+
+

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -142,7 +142,7 @@ Below topologies from ONNX open model zoo are fully supported on OpenVINO Execut
 
 To use csharp api for openvino execution provider create a custom nuget package.
 
-1.Windows
+1. Windows
 
 Build a custom nuget package for windows.
 ```
@@ -151,11 +151,19 @@ msbuild csharp\OnnxRuntime.CSharp.proj /p:Configuration=Debug /t:CreatePackage
 
 ```
 
-2.Linux
+2. Linux
 
 We currently do not have a process to build directly in Linux. But we can
 copy shared library libonnxruntime.so to onnxruntime repository in windows
 and execute the same commands above to get custom nuget package for linux 
+
+On Linux Server
+```
+./build.sh --config Debug --build_shared_lib --use_openvino $Device 
+
+```
+
+On Windows Server
 
 ```
 cp libonnxruntime.so $PATH/onnxruntime/ 

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -148,7 +148,6 @@ Build a custom nuget package for windows.
 ```
 .\build.bat --config Debug --build --use_openvino $Device --build_csharp
 msbuild csharp\OnnxRuntime.CSharp.proj /p:Configuration=Debug /t:CreatePackage
-
 ```
 
 2. Linux
@@ -160,7 +159,6 @@ and execute the same commands above to get custom nuget package for linux
 On Linux Server
 ```
 ./build.sh --config Debug --build_shared_lib --use_openvino $Device 
-
 ```
 
 On Windows Server
@@ -169,7 +167,6 @@ On Windows Server
 cp libonnxruntime.so $PATH/onnxruntime/ 
 .\build.bat --config Debug --build --use_openvino $Device --build_csharp
 msbuild csharp\OnnxRuntime.CSharp.proj /p:Configuration=Debug /t:CreatePackage
-
 ```
 
 

--- a/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
@@ -64,10 +64,10 @@ VADMBackend::VADMBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
       exe_networks.push_back(exe_network);
     }
     LOGS_DEFAULT(INFO) << log_tag << "Loaded model to the plugin";
-    for(size_t i = 0; i < num_inf_reqs_; i++) {
+    for(size_t j = 0; j < num_inf_reqs_; j++) {
       InferenceEngine::InferRequest::Ptr infRequest;
       try {
-        infRequest = exe_networks[i].CreateInferRequestPtr();
+        infRequest = exe_networks[j].CreateInferRequestPtr();
       } catch(InferenceEngine::details::InferenceEngineException e) {
         ORT_THROW(log_tag + "Exception while creating InferRequest object: " + e.what());
       } catch (...) {

--- a/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
@@ -64,10 +64,10 @@ VADMBackend::VADMBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
       exe_networks.push_back(exe_network);
     }
     LOGS_DEFAULT(INFO) << log_tag << "Loaded model to the plugin";
-    for(size_t j = 0; j < num_inf_reqs_; j++) {
+    for(size_t i = 0; i < num_inf_reqs_; i++) {
       InferenceEngine::InferRequest::Ptr infRequest;
       try {
-        infRequest = exe_networks[j].CreateInferRequestPtr();
+        infRequest = exe_networks[i].CreateInferRequestPtr();
       } catch(InferenceEngine::details::InferenceEngineException e) {
         ORT_THROW(log_tag + "Exception while creating InferRequest object: " + e.what());
       } catch (...) {

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -11,7 +11,7 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
     if (device == nullptr) {
       device_ = "";
     } else {
-      device_ = device;
+      device_ = std::string(device);
     }
   }
   ~OpenVINOProviderFactory() override {
@@ -20,7 +20,7 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
   std::unique_ptr<IExecutionProvider> CreateProvider() override;
 
  private:
-  const char* device_;
+  std::string device_;
 };
 
 std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -22,7 +22,7 @@ def parse_arguments():
     parser.add_argument("--commit_id", required=True, help="The last commit id included in this package.")
     parser.add_argument("--is_release_build", required=False, default=None, type=str,
                         help="Flag indicating if the build is a release build. Accepted values: true/false.")
-    parser.add_argument("--linux_build", required=False, default=None, type=str, 
+    parser.add_argument("--linux_build", required=False, default=None, type=str,
                         help="specify the libonnxruntime.so lib values")
 
     return parser.parse_args()
@@ -182,11 +182,10 @@ def generate_files(list, args):
                                        'include\\onnxruntime\\core\\providers\\cuda\\cuda_provider_factory.h') +
                           '" target="build\\native\\include" />')
 
-    #if includes_openvino:
     files_list.append('<file src=' + '"' +
                       os.path.join(args.sources_path,
-                      'include\\onnxruntime\\core\\providers\\openvino\\openvino_provider_factory.h') +
-                      '" target="build\\native\\include" />')    
+                                   'include\\onnxruntime\\core\\providers\\openvino\\openvino_provider_factory.h') +
+                      '" target="build\\native\\include" />')
 
     if includes_directml:
         files_list.append('<file src=' + '"' +
@@ -221,10 +220,10 @@ def generate_files(list, args):
                           '" target="lib\\netstandard2.0\\Microsoft.AI.MachineLearning.Interop.pdb" />')
 
     # Process runtimes
-    # Process linux 
+    # Process linux
     if (args.linux_build != 'None'):
         files_list.append('<file src=' + '"' + os.path.join(args.sources_path, args.linux_build) +
-                      '" target="runtimes\\linux-' + args.target_architecture + '\\native" />')
+                          '" target="runtimes\\linux-' + args.target_architecture + '\\native" />')
 
     # Process onnxruntime import lib, dll, and pdb
     files_list.append('<file src=' + '"' + os.path.join(args.native_build_path, 'onnxruntime.lib') +

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -22,6 +22,8 @@ def parse_arguments():
     parser.add_argument("--commit_id", required=True, help="The last commit id included in this package.")
     parser.add_argument("--is_release_build", required=False, default=None, type=str,
                         help="Flag indicating if the build is a release build. Accepted values: true/false.")
+    parser.add_argument("--linux_build", required=False, default=None, type=str, 
+                        help="specify the libonnxruntime.so lib values")
 
     return parser.parse_args()
 
@@ -180,6 +182,12 @@ def generate_files(list, args):
                                        'include\\onnxruntime\\core\\providers\\cuda\\cuda_provider_factory.h') +
                           '" target="build\\native\\include" />')
 
+    #if includes_openvino:
+    files_list.append('<file src=' + '"' +
+                      os.path.join(args.sources_path,
+                      'include\\onnxruntime\\core\\providers\\openvino\\openvino_provider_factory.h') +
+                      '" target="build\\native\\include" />')    
+
     if includes_directml:
         files_list.append('<file src=' + '"' +
                           os.path.join(args.sources_path,
@@ -213,6 +221,11 @@ def generate_files(list, args):
                           '" target="lib\\netstandard2.0\\Microsoft.AI.MachineLearning.Interop.pdb" />')
 
     # Process runtimes
+    # Process linux 
+    if (args.linux_build != 'None'):
+        files_list.append('<file src=' + '"' + os.path.join(args.sources_path, args.linux_build) +
+                      '" target="runtimes\\linux-' + args.target_architecture + '\\native" />')
+
     # Process onnxruntime import lib, dll, and pdb
     files_list.append('<file src=' + '"' + os.path.join(args.native_build_path, 'onnxruntime.lib') +
                       '" target="runtimes\\win-' + args.target_architecture + '\\native" />')


### PR DESCRIPTION
Changes to support openvino 

Csharp Api enabling
- Change is required so that cusomer can access openvino ep through dotnet apis. 
https://jira.devtools.intel.com/browse/HAFP-845