### PR TITLE
[Do Not merge] Enable VPU config options

### DIFF
--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -68,8 +68,15 @@ After a device type is selected is selected for inference (either during build t
 Note. This dynamic hardware selection is optional. The EP falls back to the build-time default selection if no dynamic hardware option value is specified.
 
 ### Python API
+
+Get list of available OpenVINO compatible devices
 ```
 import onnxruntime
+onnxruntime.capi._pybind_state.get_available_openvino_device_ids()
+```
+
+Select a device ID from the list obtained above
+```
 onnxruntime.capi._pybind_state.set_openvino_device_id("<device_id>")
 # Create session after this
 ```

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -8,14 +8,14 @@ For build instructions, please see the [BUILD page](../../BUILD.md#openvino).
 ## Onnxruntime Graph Optimization level
 OpenVINO backend performs both hardware dependent as well as independent optimizations to the graph to infer it with on the target hardware with best possible performance. In most of the cases it has been observed that passing in the graph from the input model as is would lead to best possible optimizations by OpenVINO. For this reason, it is advised to turn off high level optimizations performed by ONNX Runtime before handing the graph over to OpenVINO backend. This can be done using Session options as shown below:-
 
-1. Python API
+### Python API
 ```
 options = onnxruntime.SessionOptions()
 options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
 sess = onnxruntime.InferenceSession(<path_to_model_file>, options)
 ```
 
-2. C++ API
+### C/C++ API
 ```
 SessionOptions::SetGraphOptimizationLevel(ORT_DISABLE_ALL);
 ```
@@ -24,15 +24,38 @@ SessionOptions::SetGraphOptimizationLevel(ORT_DISABLE_ALL);
 When ONNX Runtime is built with OpenVINO Execution Provider, a target hardware option needs to be provided. This build time option becomes the default target harware the EP schedules inference on. However, this target may be overriden at runtime to schedule inference on a different hardware as shown below.
 
 Note. This dynamic hardware selection is optional. The EP falls back to the build-time default selection if no dynamic hardware option value is specified.
-1. Python API
+
+### Python API
 ```
 import onnxruntime
 onnxruntime.capi._pybind_state.set_openvino_device("<harware_option>")
 # Create session after this
 ```
-2. C/C++ API
+*This property persists and gets applied to new sessions until it is explicity unset. To unset, assign a null string ("").*
+
+### C/C++ API
+
+Pass the device string as the **second** argument of the call to append OpenVINO EP.
 ```
-Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "<hardware_option>"));
+Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "<hardware_option>", ... ));
+```
+
+## Enable VPU Fast-compile
+When scheduling inference on VPU, Fast-compile may be option that speeds up the model's compilation to VPU device specific format which speeds up model initialization time. However, enabling this option may slowdown inference due to some of the optimizations not being fully applied, so caution is to be exercised while enabling this.
+
+### Python API
+```
+import onnxruntime
+onnxruntime.capi._pybind_state.enable_vpu_fast_compile(True)
+# Create session after this
+```
+*This property persists and gets applied to new sessions until it is explicity unset. To unset, assign a value False to the property.*
+
+### C/C++ API
+
+Pass the boolen value as the **third** argument of the call to append OpenVINO EP.
+```
+Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "<hardware_option>", true));
 ```
 
 ## ONNX Layers supported using OpenVINO

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -2,8 +2,11 @@
 
 OpenVINO Execution Provider enables deep learning inference on Intel CPUs, Intel integrated GPUs and Intel<sup>®</sup> Movidius<sup>TM</sup> Vision Processing Units (VPUs). Please refer to [this](https://software.intel.com/en-us/openvino-toolkit/hardware) page for details on the Intel hardware supported.
 
-## Build
+### Build
 For build instructions, please see the [BUILD page](../../BUILD.md#openvino).
+
+## Runtime configuration options
+---
 
 ## Onnxruntime Graph Optimization level
 OpenVINO backend performs both hardware dependent as well as independent optimizations to the graph to infer it with on the target hardware with best possible performance. In most of the cases it has been observed that passing in the graph from the input model as is would lead to best possible optimizations by OpenVINO. For this reason, it is advised to turn off high level optimizations performed by ONNX Runtime before handing the graph over to OpenVINO backend. This can be done using Session options as shown below:-
@@ -20,7 +23,7 @@ sess = onnxruntime.InferenceSession(<path_to_model_file>, options)
 SessionOptions::SetGraphOptimizationLevel(ORT_DISABLE_ALL);
 ```
 
-## Dynamic device selection
+## Dynamic device type selection
 When ONNX Runtime is built with OpenVINO Execution Provider, a target hardware option needs to be provided. This build time option becomes the default target harware the EP schedules inference on. However, this target may be overriden at runtime to schedule inference on a different hardware as shown below.
 
 Note. This dynamic hardware selection is optional. The EP falls back to the build-time default selection if no dynamic hardware option value is specified.
@@ -40,13 +43,13 @@ Pass the device string as the **second** argument of the call to append OpenVINO
 Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "<hardware_option>", ... ));
 ```
 
-## Enable VPU Fast-compile
+## Enabling VPU Fast-compile
 When scheduling inference on VPU, Fast-compile may be option that speeds up the model's compilation to VPU device specific format which speeds up model initialization time. However, enabling this option may slowdown inference due to some of the optimizations not being fully applied, so caution is to be exercised while enabling this.
 
 ### Python API
 ```
 import onnxruntime
-onnxruntime.capi._pybind_state.enable_vpu_fast_compile(True)
+onnxruntime.capi._pybind_state.set_vpu_fast_compile(True)
 # Create session after this
 ```
 *This property persists and gets applied to new sessions until it is explicity unset. To unset, assign a value False to the property.*
@@ -56,6 +59,27 @@ onnxruntime.capi._pybind_state.enable_vpu_fast_compile(True)
 Pass the boolen value as the **third** argument of the call to append OpenVINO EP.
 ```
 Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "<hardware_option>", true));
+```
+
+
+## Dynamic device id selection
+After a device type is selected is selected for inference (either during build time or run time), a specific physical hardware device of the type that is available on the host may optionally be specified for inference.
+
+Note. This dynamic hardware selection is optional. The EP falls back to the build-time default selection if no dynamic hardware option value is specified.
+
+### Python API
+```
+import onnxruntime
+onnxruntime.capi._pybind_state.set_openvino_device_id("<device_id>")
+# Create session after this
+```
+*This property persists and gets applied to new sessions until it is explicity unset. To unset, assign a null string ("").*
+
+### C/C++ API
+
+Pass the device string as the **third** argument of the call to append OpenVINO EP.
+```
+Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "<hardware_option>", <vpu_fast_compile>, <device_id> ));
 ```
 
 ## ONNX Layers supported using OpenVINO

--- a/include/onnxruntime/core/providers/openvino/openvino_provider_factory.h
+++ b/include/onnxruntime/core/providers/openvino/openvino_provider_factory.h
@@ -5,13 +5,15 @@
 
 #ifdef __cplusplus
 extern "C" {
+#else
+#include <stdbool.h>
 #endif
 
 /**
  * \param device_id openvino device id, starts from zero.
  */
 ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_OpenVINO,
-    _In_ OrtSessionOptions* options, const char* device_id);
+    _In_ OrtSessionOptions* options, const char* device_id, bool enable_vpu_fast_compile);
 
 #ifdef __cplusplus
 }

--- a/include/onnxruntime/core/providers/openvino/openvino_provider_factory.h
+++ b/include/onnxruntime/core/providers/openvino/openvino_provider_factory.h
@@ -13,7 +13,8 @@ extern "C" {
  * \param device_id openvino device id, starts from zero.
  */
 ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_OpenVINO,
-    _In_ OrtSessionOptions* options, const char* device_id, bool enable_vpu_fast_compile);
+    _In_ OrtSessionOptions* options, const char* device_type,
+    bool enable_vpu_fast_compile, const char* device_id);
 
 #ifdef __cplusplus
 }

--- a/onnxruntime/core/providers/openvino/backend_manager.h
+++ b/onnxruntime/core/providers/openvino/backend_manager.h
@@ -20,8 +20,7 @@ namespace openvino_ep {
 // Singleton class that manages all the backends
 class BackendManager {
  public:
-  BackendManager(const onnxruntime::Node* fused_node, const logging::Logger& logger,
-                 std::string dev_id, std::string prec_str);
+  BackendManager(const onnxruntime::Node* fused_node, const logging::Logger& logger);
   void Compute(Ort::CustomOpApi api, OrtKernelContext* context);
   void ShutdownBackendManager();
   static GlobalContext& GetGlobalContext();

--- a/onnxruntime/core/providers/openvino/backend_utils.h
+++ b/onnxruntime/core/providers/openvino/backend_utils.h
@@ -23,7 +23,7 @@ void SetIODefs(const ONNX_NAMESPACE::ModelProto& model_proto,
                std::map<std::string, std::shared_ptr<ngraph::Node>>& const_outputs_map);
 
 std::shared_ptr<InferenceEngine::CNNNetwork>
-CreateCNNNetwork(const ONNX_NAMESPACE::ModelProto& model_proto, const SubGraphContext& subgraph_context, std::map<std::string,
+CreateCNNNetwork(const ONNX_NAMESPACE::ModelProto& model_proto, const GlobalContext& global_context, const SubGraphContext& subgraph_context, std::map<std::string,
                    std::shared_ptr<ngraph::Node>>& const_outputs_map);
 
 int GetFirstAvailableDevice(GlobalContext& global_context);

--- a/onnxruntime/core/providers/openvino/backends/backend_factory.cc
+++ b/onnxruntime/core/providers/openvino/backends/backend_factory.cc
@@ -16,7 +16,7 @@ std::shared_ptr<IBackend>
 BackendFactory::MakeBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                             GlobalContext& global_context,
                             const SubGraphContext& subgraph_context) {
-  std::string type = subgraph_context.device_id;
+  std::string type = global_context.device_type;
   if (type == "CPU" || type == "GPU" || type == "MYRIAD" || type == "HETERO:FPGA,CPU") {
     return std::make_shared<BasicBackend>(model_proto, global_context, subgraph_context);
   } else if (type == "HDDL") {

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -51,6 +51,8 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
   std::map<std::string, std::string> config;
   if(subgraph_context_.device_id == "MYRIAD" && subgraph_context_.set_vpu_config){
     config["VPU_DETECT_NETWORK_BATCH"] = CONFIG_VALUE(NO);
+    config["VPU_HW_INJECT_STAGES"] = CONFIG_VALUE(NO);
+    config["VPU_COPY_OPTIMIZATION"] = CONFIG_VALUE(NO);
   }
   try {
     exe_network = global_context_.ie_core.LoadNetwork(*ie_cnn_network_, subgraph_context_.device_id, config);

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -36,7 +36,7 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                            const SubGraphContext& subgraph_context)
     : global_context_(global_context), subgraph_context_(subgraph_context) {
 
-  ie_cnn_network_ = CreateCNNNetwork(model_proto, subgraph_context_, const_outputs_map_);
+  ie_cnn_network_ = CreateCNNNetwork(model_proto, global_context_, subgraph_context_, const_outputs_map_);
   SetIODefs(model_proto, ie_cnn_network_, subgraph_context_.output_names, const_outputs_map_);
   InferenceEngine::ExecutableNetwork exe_network;
 
@@ -49,7 +49,7 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
   if(subgraph_context_.is_constant)
     return;
   std::map<std::string, std::string> config;
-  if(subgraph_context_.device_id == "MYRIAD"){
+  if(global_context_.device_type == "MYRIAD"){
 
     if(subgraph_context_.set_vpu_config) {
       config["VPU_DETECT_NETWORK_BATCH"] = CONFIG_VALUE(NO);
@@ -60,8 +60,9 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
       config["VPU_COPY_OPTIMIZATION"] = CONFIG_VALUE(NO);
     }
   }
+  std::string& hw_target = (global_context_.device_id != "") ? global_context_.device_id : global_context_.device_type;
   try {
-    exe_network = global_context_.ie_core.LoadNetwork(*ie_cnn_network_, subgraph_context_.device_id, config);
+    exe_network = global_context_.ie_core.LoadNetwork(*ie_cnn_network_, hw_target, config);
   } catch (InferenceEngine::details::InferenceEngineException e) {
     ORT_THROW(log_tag + " Exception while Loading Network for graph: " + subgraph_context_.subgraph_name + ": " +  e.what());
   } catch (...) {

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -49,10 +49,16 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
   if(subgraph_context_.is_constant)
     return;
   std::map<std::string, std::string> config;
-  if(subgraph_context_.device_id == "MYRIAD" && subgraph_context_.set_vpu_config){
-    config["VPU_DETECT_NETWORK_BATCH"] = CONFIG_VALUE(NO);
-    config["VPU_HW_INJECT_STAGES"] = CONFIG_VALUE(NO);
-    config["VPU_COPY_OPTIMIZATION"] = CONFIG_VALUE(NO);
+  if(subgraph_context_.device_id == "MYRIAD"){
+
+    if(subgraph_context_.set_vpu_config) {
+      config["VPU_DETECT_NETWORK_BATCH"] = CONFIG_VALUE(NO);
+    }
+
+    if(global_context_.enable_vpu_fast_compile) {
+      config["VPU_HW_INJECT_STAGES"] = CONFIG_VALUE(NO);
+      config["VPU_COPY_OPTIMIZATION"] = CONFIG_VALUE(NO);
+    }
   }
   try {
     exe_network = global_context_.ie_core.LoadNetwork(*ie_cnn_network_, subgraph_context_.device_id, config);

--- a/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
@@ -47,7 +47,7 @@ VADMBackend::VADMBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
   // sets number of maximum parallel inferences
   num_inf_reqs_ = 8;
 
-  ie_cnn_network_ = CreateCNNNetwork(model_proto, subgraph_context_, const_outputs_map_);
+  ie_cnn_network_ = CreateCNNNetwork(model_proto, global_context_, subgraph_context_, const_outputs_map_);
 
   SetIODefs(model_proto, ie_cnn_network_, subgraph_context_.output_names, const_outputs_map_);
   std::map<std::string, std::string> config;

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -12,6 +12,7 @@ namespace openvino_ep {
 struct GlobalContext {
   InferenceEngine::Core ie_core;
   bool is_wholly_supported_graph = false;
+  bool enable_vpu_fast_compile = false;
   std::vector<bool> deviceAvailableList = {true, true, true, true, true, true, true, true};
   std::vector<std::string> deviceTags = {"0", "1", "2", "3", "4", "5", "6", "7"};
 };

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -13,6 +13,9 @@ struct GlobalContext {
   InferenceEngine::Core ie_core;
   bool is_wholly_supported_graph = false;
   bool enable_vpu_fast_compile = false;
+  std::string device_type;
+  std::string precision_str;
+  std::string device_id;
   std::vector<bool> deviceAvailableList = {true, true, true, true, true, true, true, true};
   std::vector<std::string> deviceTags = {"0", "1", "2", "3", "4", "5", "6", "7"};
 };
@@ -30,9 +33,7 @@ struct SubGraphContext {
   std::unordered_map<std::string, int> input_names;
   #endif
   std::unordered_map<std::string, int> output_names;
-  std::string device_id;
   InferenceEngine::Precision precision;
-  std::string precision_str;
 };
 
 }  // namespace openvino_ep

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -19,9 +19,30 @@ namespace onnxruntime {
 constexpr const char* OpenVINO = "OpenVINO";
 
 OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProviderInfo& info)
-    : IExecutionProvider{onnxruntime::kOpenVINOExecutionProvider}, info_(info) {
+    : IExecutionProvider{onnxruntime::kOpenVINOExecutionProvider} { //, info_(info) {
 
-  openvino_ep::BackendManager::GetGlobalContext().enable_vpu_fast_compile = info_.enable_vpu_fast_compile_;
+  openvino_ep::BackendManager::GetGlobalContext().device_type = info.device_type_;
+  openvino_ep::BackendManager::GetGlobalContext().precision_str = info.precision_;
+  openvino_ep::BackendManager::GetGlobalContext().enable_vpu_fast_compile = info.enable_vpu_fast_compile_;
+  if(info.device_id_ != "") {
+    bool device_found = false;
+    auto available_devices = openvino_ep::BackendManager::GetGlobalContext().ie_core.GetAvailableDevices();
+    for(auto device : available_devices) {
+      if(device == info.device_id_) {
+        device_found = true;
+        break;
+      }
+    }
+    if(!device_found) {
+      std::string err_msg = std::string("Device not found : ") + info.device_id_ + "\nChoose one of:\n";
+      for(auto device : available_devices) {
+        err_msg = err_msg + device + "\n";
+      }
+      ORT_THROW(err_msg);
+    }
+  }
+  openvino_ep::BackendManager::GetGlobalContext().device_id = info.device_id_;
+
   AllocatorCreationInfo device_info(
       [](int) {
         return std::make_unique<CPUAllocator>(OrtMemoryInfo(OpenVINO, OrtDeviceAllocator));
@@ -38,9 +59,11 @@ OpenVINOExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_v
   std::vector<std::unique_ptr<ComputeCapability>> result;
 
 #if (defined OPENVINO_2020_2) || (defined OPENVINO_2020_3)
-  result = openvino_ep::GetCapability_2020_2(graph_viewer, info_.device_id_);
+  result = openvino_ep::GetCapability_2020_2(graph_viewer,
+                          openvino_ep::BackendManager::GetGlobalContext().device_type);
 #elif defined OPENVINO_2020_4
-  result = openvino_ep::GetCapability_2020_4(graph_viewer, info_.device_id_);
+  result = openvino_ep::GetCapability_2020_4(graph_viewer,
+                          openvino_ep::BackendManager::GetGlobalContext().device_type);
 #endif
 
   return result;
@@ -51,7 +74,7 @@ common::Status OpenVINOExecutionProvider::Compile(
     std::vector<NodeComputeInfo>& node_compute_funcs) {
   for (const auto& fused_node : fused_nodes) {
     NodeComputeInfo compute_info;
-    std::shared_ptr<openvino_ep::BackendManager> backend_manager = std::make_shared<openvino_ep::BackendManager>(fused_node, *GetLogger(), info_.device_id_, info_.precision_);
+    std::shared_ptr<openvino_ep::BackendManager> backend_manager = std::make_shared<openvino_ep::BackendManager>(fused_node, *GetLogger());
 
     compute_info.create_state_func =
         [backend_manager](ComputeContext* context, FunctionState* state) {

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -19,7 +19,7 @@ namespace onnxruntime {
 constexpr const char* OpenVINO = "OpenVINO";
 
 OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProviderInfo& info)
-    : IExecutionProvider{onnxruntime::kOpenVINOExecutionProvider} { //, info_(info) {
+    : IExecutionProvider{onnxruntime::kOpenVINOExecutionProvider} {
 
   openvino_ep::BackendManager::GetGlobalContext().device_type = info.device_type_;
   openvino_ep::BackendManager::GetGlobalContext().precision_str = info.precision_;

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -20,6 +20,8 @@ constexpr const char* OpenVINO = "OpenVINO";
 
 OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProviderInfo& info)
     : IExecutionProvider{onnxruntime::kOpenVINOExecutionProvider}, info_(info) {
+
+  openvino_ep::BackendManager::GetGlobalContext().enable_vpu_fast_compile = info_.enable_vpu_fast_compile_;
   AllocatorCreationInfo device_info(
       [](int) {
         return std::make_unique<CPUAllocator>(OrtMemoryInfo(OpenVINO, OrtDeviceAllocator));

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -101,8 +101,6 @@ class OpenVINOExecutionProvider : public IExecutionProvider {
   const void* GetExecutionHandle() const noexcept override {
     return nullptr;
   }
- private:
-  // OpenVINOExecutionProviderInfo info_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -22,30 +22,25 @@ struct OpenVINOExecutionProviderInfo {
     if (dev_id == "") {
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
                          << "No runtime device selection option provided.";
-#ifdef OPENVINO_CONFIG_CPU_FP32
+      #if defined OPENVINO_CONFIG_CPU_FP32
       device_id_ = "CPU";
       precision_ = "FP32";
-#endif
-#ifdef OPENVINO_CONFIG_GPU_FP32
+      #elif defined OPENVINO_CONFIG_GPU_FP32
       device_id_ = "GPU";
       precision_ = "FP32";
-#endif
-#ifdef OPENVINO_CONFIG_GPU_FP16
+      #elif defined OPENVINO_CONFIG_GPU_FP16
       device_id_ = "GPU";
       precision_ = "FP16";
-#endif
-#ifdef OPENVINO_CONFIG_MYRIAD
+      #elif defined OPENVINO_CONFIG_MYRIAD
       device_id_ = "MYRIAD";
       precision_ = "FP16";
-#endif
-#ifdef OPENVINO_CONFIG_VAD_M
+      #elif defined OPENVINO_CONFIG_VAD_M
       device_id_ = "HDDL";
       precision_ = "FP16";
-#endif
-#ifdef OPENVINO_CONFIG_VAD_F
+      #elif defined OPENVINO_CONFIG_VAD_F
       device_id_ = "HETERO:FPGA,CPU";
       precision_ = "FP32";
-#endif
+      #endif
     } else if (dev_id == "CPU_FP32") {
       device_id_ = "CPU";
       precision_ = "FP32";

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -15,61 +15,62 @@ namespace onnxruntime {
 
 // Information needed to construct OpenVINO execution providers.
 struct OpenVINOExecutionProviderInfo {
-  std::string device_id_;
+  std::string device_type_;
   std::string precision_;
   bool enable_vpu_fast_compile_;
+  std::string device_id_;
 
-  explicit OpenVINOExecutionProviderInfo(std::string dev_id, bool enable_vpu_fast_compile = false)
-            : enable_vpu_fast_compile_(enable_vpu_fast_compile) {
+  explicit OpenVINOExecutionProviderInfo(std::string dev_type, bool enable_vpu_fast_compile, std::string dev_id)
+            : enable_vpu_fast_compile_(enable_vpu_fast_compile), device_id_(dev_id) {
 
-    if (dev_id == "") {
+    if (dev_type == "") {
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
                          << "No runtime device selection option provided.";
       #if defined OPENVINO_CONFIG_CPU_FP32
-      device_id_ = "CPU";
+      device_type_ = "CPU";
       precision_ = "FP32";
       #elif defined OPENVINO_CONFIG_GPU_FP32
-      device_id_ = "GPU";
+      device_type_ = "GPU";
       precision_ = "FP32";
       #elif defined OPENVINO_CONFIG_GPU_FP16
-      device_id_ = "GPU";
+      device_type_ = "GPU";
       precision_ = "FP16";
       #elif defined OPENVINO_CONFIG_MYRIAD
-      device_id_ = "MYRIAD";
+      device_type_ = "MYRIAD";
       precision_ = "FP16";
       #elif defined OPENVINO_CONFIG_VAD_M
-      device_id_ = "HDDL";
+      device_type_ = "HDDL";
       precision_ = "FP16";
       #elif defined OPENVINO_CONFIG_VAD_F
-      device_id_ = "HETERO:FPGA,CPU";
+      device_type_ = "HETERO:FPGA,CPU";
       precision_ = "FP32";
       #endif
-    } else if (dev_id == "CPU_FP32") {
-      device_id_ = "CPU";
+    } else if (dev_type == "CPU_FP32") {
+      device_type_ = "CPU";
       precision_ = "FP32";
-    } else if (dev_id == "GPU_FP32") {
-      device_id_ = "GPU";
+    } else if (dev_type == "GPU_FP32") {
+      device_type_ = "GPU";
       precision_ = "FP32";
-    } else if (dev_id == "GPU_FP16") {
-      device_id_ = "GPU";
+    } else if (dev_type == "GPU_FP16") {
+      device_type_ = "GPU";
       precision_ = "FP16";
-    } else if (dev_id == "MYRIAD_FP16") {
-      device_id_ = "MYRIAD";
+    } else if (dev_type == "MYRIAD_FP16") {
+      device_type_ = "MYRIAD";
       precision_ = "FP16";
-    } else if (dev_id == "VAD-M_FP16") {
-      device_id_ = "HDDL";
+    } else if (dev_type == "VAD-M_FP16") {
+      device_type_ = "HDDL";
       precision_ = "FP16";
-    } else if (dev_id == "VAD-F_FP32") {
-      device_id_ = "HETERO:FPGA,CPU";
+    } else if (dev_type == "VAD-F_FP32") {
+      device_type_ = "HETERO:FPGA,CPU";
       precision_ = "FP32";
     } else {
-      ORT_THROW("Invalid device string: " + dev_id);
+      ORT_THROW("Invalid device string: " + dev_type);
     }
     LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
-                       << "Choosing Device: " << device_id_ << " , Precision: " << precision_;
+                       << "Choosing Device: " << device_type_ << " , Precision: " << precision_;
   }
   OpenVINOExecutionProviderInfo() {
-    OpenVINOExecutionProviderInfo("");
+    OpenVINOExecutionProviderInfo("", false, "");
   }
 };
 
@@ -101,7 +102,7 @@ class OpenVINOExecutionProvider : public IExecutionProvider {
     return nullptr;
   }
  private:
-  OpenVINOExecutionProviderInfo info_;
+  // OpenVINOExecutionProviderInfo info_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -17,8 +17,11 @@ namespace onnxruntime {
 struct OpenVINOExecutionProviderInfo {
   std::string device_id_;
   std::string precision_;
+  bool enable_vpu_fast_compile_;
 
-  explicit OpenVINOExecutionProviderInfo(std::string dev_id) {
+  explicit OpenVINOExecutionProviderInfo(std::string dev_id, bool enable_vpu_fast_compile = false)
+            : enable_vpu_fast_compile_(enable_vpu_fast_compile) {
+
     if (dev_id == "") {
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
                          << "No runtime device selection option provided.";

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -7,13 +7,11 @@
 
 namespace onnxruntime {
 struct OpenVINOProviderFactory : IExecutionProviderFactory {
-  OpenVINOProviderFactory(const char* device, bool enable_vpu_fast_compile)
+  OpenVINOProviderFactory(const char* device_type, bool enable_vpu_fast_compile,
+                          const char* device_id)
     : enable_vpu_fast_compile_(enable_vpu_fast_compile) {
-    if (device == nullptr) {
-      device_ = "";
-    } else {
-      device_ = device;
-    }
+    device_type_ = (device_type == nullptr) ? "" : device_type;
+    device_id_ = (device_id == nullptr) ? "" : device_id;
   }
   ~OpenVINOProviderFactory() override {
   }
@@ -21,25 +19,27 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
   std::unique_ptr<IExecutionProvider> CreateProvider() override;
 
  private:
-  std::string device_;
+  std::string device_type_;
   bool enable_vpu_fast_compile_;
+  std::string device_id_;
 };
 
 std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {
-  OpenVINOExecutionProviderInfo info(device_, enable_vpu_fast_compile_);
+  OpenVINOExecutionProviderInfo info(device_type_, enable_vpu_fast_compile_, device_id_);
   return std::make_unique<OpenVINOExecutionProvider>(info);
 }
 
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(
-    const char* device_id, bool enable_vpu_fast_compile) {
-  return std::make_shared<onnxruntime::OpenVINOProviderFactory>(device_id, enable_vpu_fast_compile);
+    const char* device_type, bool enable_vpu_fast_compile, const char* device_id) {
+  return std::make_shared<onnxruntime::OpenVINOProviderFactory>(device_type, enable_vpu_fast_compile, device_id);
 }
 
 }  // namespace onnxruntime
 
 ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_OpenVINO,
-                    _In_ OrtSessionOptions* options, const char* device_id, bool enable_vpu_fast_compile) {
+                    _In_ OrtSessionOptions* options, const char* device_type,
+                    bool enable_vpu_fast_compile, const char* device_id) {
   options->provider_factories.push_back(
-      onnxruntime::CreateExecutionProviderFactory_OpenVINO(device_id, enable_vpu_fast_compile));
+      onnxruntime::CreateExecutionProviderFactory_OpenVINO(device_type, enable_vpu_fast_compile, device_id));
   return nullptr;
 }

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -7,7 +7,8 @@
 
 namespace onnxruntime {
 struct OpenVINOProviderFactory : IExecutionProviderFactory {
-  OpenVINOProviderFactory(const char* device) {
+  OpenVINOProviderFactory(const char* device, bool enable_vpu_fast_compile)
+    : enable_vpu_fast_compile_(enable_vpu_fast_compile) {
     if (device == nullptr) {
       device_ = "";
     } else {
@@ -21,23 +22,24 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
 
  private:
   std::string device_;
+  bool enable_vpu_fast_compile_;
 };
 
 std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {
-  OpenVINOExecutionProviderInfo info(device_);
+  OpenVINOExecutionProviderInfo info(device_, enable_vpu_fast_compile_);
   return std::make_unique<OpenVINOExecutionProvider>(info);
 }
 
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(
-    const char* device_id) {
-  return std::make_shared<onnxruntime::OpenVINOProviderFactory>(device_id);
+    const char* device_id, bool enable_vpu_fast_compile) {
+  return std::make_shared<onnxruntime::OpenVINOProviderFactory>(device_id, enable_vpu_fast_compile);
 }
 
 }  // namespace onnxruntime
 
 ORT_API_STATUS_IMPL(OrtSessionOptionsAppendExecutionProvider_OpenVINO,
-                    _In_ OrtSessionOptions* options, const char* device_id) {
+                    _In_ OrtSessionOptions* options, const char* device_id, bool enable_vpu_fast_compile) {
   options->provider_factories.push_back(
-      onnxruntime::CreateExecutionProviderFactory_OpenVINO(device_id));
+      onnxruntime::CreateExecutionProviderFactory_OpenVINO(device_id, enable_vpu_fast_compile));
   return nullptr;
 }

--- a/onnxruntime/core/providers/openvino/ov_versions/capabilities.h
+++ b/onnxruntime/core/providers/openvino/ov_versions/capabilities.h
@@ -7,11 +7,11 @@ namespace openvino_ep {
 
 #if (defined OPENVINO_2020_2) || (defined OPENVINO_2020_3)
 std::vector<std::unique_ptr<ComputeCapability>>
-GetCapability_2020_2(const onnxruntime::GraphViewer& graph_viewer, const std::string device_id);
+GetCapability_2020_2(const onnxruntime::GraphViewer& graph_viewer, const std::string device_type);
 
 #elif defined OPENVINO_2020_4
 std::vector<std::unique_ptr<ComputeCapability>>
-GetCapability_2020_4(const onnxruntime::GraphViewer& graph_viewer, const std::string device_id);
+GetCapability_2020_4(const onnxruntime::GraphViewer& graph_viewer, const std::string device_type);
 
 #endif
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -23,6 +23,10 @@
 #include "core/session/abi_session_options_impl.h"
 #include "core/platform/env.h"
 
+#if USE_OPENVINO
+#include <inference_engine.hpp>
+#endif
+
 struct OrtStatus {
   OrtErrorCode code;
   char msg[1];  // a null-terminated string
@@ -707,6 +711,12 @@ void addGlobalMethods(py::module& m, const Environment& env) {
         return enable_vpu_fast_compile;
       },
       "Gets the status of VPU fast compile selection.");
+  m.def(
+      "get_available_openvino_device_ids", []() -> std::vector<std::string> {
+        InferenceEngine::Core ie_core;
+        return ie_core.GetAvailableDevices();
+      },
+      "Lists all OpenVINO device ids available.");
   m.def(
       "set_openvino_device_id", [](const std::string& device_id) { openvino_device_id = device_id; },
       "Set the prefered OpenVINO device id of a type to be used. If left unset, an arbitrary free device of type will be used.");

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -325,7 +325,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
         sf.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
       }
 
-      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, ""));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "", false));
 #else
       fprintf(stderr, "OpenVINO is not supported in this build");
       return -1;

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -325,7 +325,7 @@ int real_main(int argc, char* argv[], Ort::Env& env) {
         sf.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
       }
 
-      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "", false));
+      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(sf, "", false, ""));
 #else
       fprintf(stderr, "OpenVINO is not supported in this build");
       return -1;

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -65,7 +65,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
 #endif
  } else if (provider_name == onnxruntime::kOpenVINOExecutionProvider) {
 #ifdef USE_OPENVINO
-    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(session_options, ""));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(session_options, "", false));
 #else
     ORT_THROW("OpenVINO is not supported in this build\n");
 #endif

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -65,7 +65,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
 #endif
  } else if (provider_name == onnxruntime::kOpenVINOExecutionProvider) {
 #ifdef USE_OPENVINO
-    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(session_options, "", false));
+    Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_OpenVINO(session_options, "", false, ""));
 #else
     ORT_THROW("OpenVINO is not supported in this build\n");
 #endif

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -15,7 +15,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_CUDA(O
                                                                                ArenaExtendStrategy arena_extend_strategy = ArenaExtendStrategy::kNextPowerOfTwo);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(int use_arena);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_NGraph(const char* ng_backend_type);
-std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(const char* device_id);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(const char* device_id, bool enable_vpu_fast_compile = false);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Nuphar(bool, const char*);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Nnapi();
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Rknpu();

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -15,7 +15,7 @@ std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_CUDA(O
                                                                                ArenaExtendStrategy arena_extend_strategy = ArenaExtendStrategy::kNextPowerOfTwo);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Dnnl(int use_arena);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_NGraph(const char* ng_backend_type);
-std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(const char* device_id, bool enable_vpu_fast_compile = false);
+std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(const char* device_type, bool enable_vpu_fast_compile, const char* device_id);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Nuphar(bool, const char*);
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Nnapi();
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_Rknpu();
@@ -48,7 +48,7 @@ std::unique_ptr<IExecutionProvider> DefaultMIGraphXExecutionProvider() {
 
 std::unique_ptr<IExecutionProvider> DefaultOpenVINOExecutionProvider() {
 #ifdef USE_OPENVINO
-  return CreateExecutionProviderFactory_OpenVINO("")->CreateProvider();
+  return CreateExecutionProviderFactory_OpenVINO("", false, "")->CreateProvider();
 #else
   return nullptr;
 #endif


### PR DESCRIPTION
**Description**: Adds two OpenVINO EP configuration options:-
1. Enable Fast compilation of models for VPU hardware
2. Select specific hardware device id as target for inference

**Motivation and Context**
- Fast compilation is helpful for large models being initialized on slow CPU/low memory devices.
- Allowing specific device id selection provides finer grain control over OpenVINO inference targets.