### PR TITLE
Surya/cleanup inference code

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.h
+++ b/onnxruntime/core/providers/openvino/backend_utils.h
@@ -39,11 +39,24 @@ void FillOutputHelper(Ort::CustomOpApi& ort, OrtValue* out_tensor, std::shared_p
 InferenceEngine::Precision
 ConvertPrecisionONNXToOpenVINO(const ONNX_NAMESPACE::TypeProto& onnx_type, std::string device);
 
-std::vector<OrtValue*> GetOutputTensors(Ort::CustomOpApi& ort,
-                                        OrtKernelContext* context, size_t batch_size,
-                                        InferenceEngine::InferRequest::Ptr infer_request,
-                                        std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network,
-                                        std::unordered_map<std::string, int> output_names, std::map<std::string, std::shared_ptr<ngraph::Node>> const_output_map);
+OrtValue*
+GetOutputTensor(Ort::CustomOpApi& ort, OrtKernelContext* context, size_t batch_size,
+                 InferenceEngine::InferRequest::Ptr infer_request,
+                 std::string output_name,
+                 std::unordered_map<std::string, int> output_names);
+
+OrtValue*
+GetOutputTensor(Ort::CustomOpApi& ort, OrtKernelContext* context,
+                 std::string output_name,
+                 std::unordered_map<std::string, int> output_names,
+                 std::shared_ptr<ngraph::Node> node);
+
+void FillInputBlob(InferenceEngine::Blob::Ptr& inputBlob, size_t request_id, size_t batch_slice_idx,
+                   std::string input_name, Ort::CustomOpApi& ort, OrtKernelContext* context,
+                   InferenceEngine::Precision precision, const SubGraphContext& subgraph_context);
+
+void FillOutputBlob(InferenceEngine::Blob::Ptr& outputBlob, OrtValue* output_tensor,
+                    Ort::CustomOpApi& ort, InferenceEngine::Precision precision, size_t batch_slice_idx);
 
 }  // namespace backend_utils
 }  // namespace openvino_ep

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -24,13 +24,6 @@ namespace openvino_ep {
 
 using namespace backend_utils;
 
-
-struct static_cast_int64
-{
-  template <typename T1> // T1 models type statically convertible to T
-  int64_t operator()(const T1& x) const { return static_cast<int64_t>(x); }
-};
-
 BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                            GlobalContext& global_context,
                            const SubGraphContext& subgraph_context)
@@ -84,20 +77,18 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
 
 // Starts an asynchronous inference request for data in slice indexed by batch_slice_idx on
 // an Infer Request indexed by infer_req_idx
-void BasicBackend::StartAsyncInference(Ort::CustomOpApi& ort,
-                                       OrtKernelContext* context,
-                                       InferenceEngine::InferRequest::Ptr infer_request,
-                                       std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network) {
-  auto graph_input_info = ie_cnn_network->getInputsInfo();
+void BasicBackend::StartAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context) {
 
-  size_t i = 0;
+  auto graph_input_info = ie_cnn_network_->getInputsInfo();
+
+  size_t index = 0;
   for (auto input_info_iter = graph_input_info.begin();
-       input_info_iter != graph_input_info.end(); ++input_info_iter, ++i) {
+       input_info_iter != graph_input_info.end(); ++input_info_iter, ++index) {
     // Get OpenVINO's input buffer
     InferenceEngine::Blob::Ptr graph_input_blob;
     std::string input_name = input_info_iter->first;
     try {
-      graph_input_blob = infer_request->GetBlob(input_name);
+      graph_input_blob = infer_request_->GetBlob(input_name);
 
     } catch (InferenceEngine::details::InferenceEngineException e) {
       ORT_THROW(log_tag + " Cannot access IE Blob for input: " + input_name + e.what());
@@ -105,38 +96,12 @@ void BasicBackend::StartAsyncInference(Ort::CustomOpApi& ort,
       ORT_THROW(log_tag + " Cannot access IE Blob for input: " + input_name);
     }
     auto precision = input_info_iter->second->getPrecision();
-    auto graph_input_buffer = graph_input_blob->buffer()
-                                  .as<InferenceEngine::PrecisionTrait<InferenceEngine::Precision::FP32>::value_type*>();
-    size_t input_data_size = graph_input_blob->byteSize();
-
-    #if (defined OPENVINO_2020_2) || (defined OPENVINO_2020_3)
-    const OrtValue* tensor = ort.KernelContext_GetInput(context, subgraph_context_.input_indexes[i]);
-    #else
-    const OrtValue* tensor = ort.KernelContext_GetInput(context, subgraph_context_.input_names.at(input_name));
-    #endif
-
-    auto tensor_shape = ort.GetTensorTypeAndShape(tensor);
-    auto elem_type = ort.GetTensorElementType(tensor_shape);
-
-    if ((elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) &&
-        (precision == InferenceEngine::Precision::I32)) {
-
-      const int64_t* tensor_data_64 = ort.GetTensorData<int64_t>(tensor);
-      auto data_len = (input_data_size * 2) / sizeof(int64_t)  ;
-
-      std::copy(tensor_data_64, tensor_data_64+data_len, (uint32_t*)graph_input_buffer);
-    } else {
-
-      // Copy input data into OpenVINO's input buffer
-      const char* tensor_data = ort.GetTensorData<char>(tensor);
-      std::memcpy(graph_input_buffer, tensor_data, input_data_size);
-
-    }
-
+    size_t batch_slice = 0;
+    FillInputBlob(graph_input_blob, index, batch_slice, input_name, ort, context, precision, subgraph_context_);
   }
   // Start Async inference
   try {
-    infer_request->StartAsync();
+    infer_request_->StartAsync();
   } catch (InferenceEngine::details::InferenceEngineException e) {
     ORT_THROW(log_tag + " Couldn't start Inference: " + e.what());
   } catch (...) {
@@ -146,64 +111,44 @@ void BasicBackend::StartAsyncInference(Ort::CustomOpApi& ort,
 
 // Wait for asynchronous inference completion on an Infer Request object indexed by infer_req_idx
 // and copy the results into a slice location within the batched output buffer indexed by batch_slice_idx
-void BasicBackend::CompleteAsyncInference(Ort::CustomOpApi& ort,
-                                          std::vector<OrtValue*> output_tensors,
-                                          InferenceEngine::InferRequest::Ptr infer_request,
-                                          std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network) {
+void BasicBackend::CompleteAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context) {
   // Wait for Async inference completion
   try {
-    infer_request->Wait(InferenceEngine::IInferRequest::WaitMode::RESULT_READY);
+    infer_request_->Wait(InferenceEngine::IInferRequest::WaitMode::RESULT_READY);
   } catch (InferenceEngine::details::InferenceEngineException e) {
     ORT_THROW(log_tag + " Exception with completing Inference: " + e.what());
   } catch (...) {
     ORT_THROW(log_tag + " Exception with completing Inference");
   }
-  auto graph_output_info = ie_cnn_network->getOutputsInfo();
+  auto graph_output_info = ie_cnn_network_->getOutputsInfo();
 
-  size_t i = 0;
   for (auto output_info_iter = graph_output_info.begin();
-       output_info_iter != graph_output_info.end(); ++output_info_iter, ++i) {
+       output_info_iter != graph_output_info.end(); ++output_info_iter) {
     // Get OpenVINO's output blob
     InferenceEngine::Blob::Ptr graph_output_blob;
+    auto output_name = output_info_iter->first;
     try {
-      graph_output_blob = infer_request->GetBlob(output_info_iter->first);
+      graph_output_blob = infer_request_->GetBlob(output_name);
     } catch (InferenceEngine::details::InferenceEngineException e) {
-      ORT_THROW(log_tag + " Cannot access IE Blob for output: " + output_info_iter->first + e.what());
+      ORT_THROW(log_tag + " Cannot access IE Blob for output: " + output_name + e.what());
     } catch (...) {
-      ORT_THROW(log_tag + " Cannot access IE Blob for output: " + output_info_iter->first);
+      ORT_THROW(log_tag + " Cannot access IE Blob for output: " + output_name);
     }
-
-    auto graph_output_buffer = graph_output_blob->buffer()
-                                   .as<InferenceEngine::PrecisionTrait<InferenceEngine::Precision::FP32>::value_type*>();
-
-    size_t output_data_size = graph_output_blob->byteSize();
-
-    auto tensor_shape = ort.GetTensorTypeAndShape(output_tensors[i]);
-    auto elem_type = ort.GetTensorElementType(tensor_shape);
+    size_t batch_size = 1;
+    auto output_tensor = GetOutputTensor(ort, context, batch_size, infer_request_, output_name, subgraph_context_.output_names);
     auto precision = output_info_iter->second->getPrecision();
 
-   if ((elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) &&
-       (precision == InferenceEngine::Precision::I32)) {
-
-      int64_t* tensor_data = ort.GetTensorMutableData<int64_t>(output_tensors[i]);
-
-      auto data_len = output_data_size/sizeof(int32_t);
-      std::transform((int32_t*)graph_output_buffer,((int32_t*)graph_output_buffer) + data_len, tensor_data, static_cast_int64());
-
-    } else {
-      char* tensor_data = ort.GetTensorMutableData<char>(output_tensors[i]);
-      std::memcpy(tensor_data, graph_output_buffer, output_data_size);
-
-    }
+    size_t batch_slice = 0;
+    FillOutputBlob(graph_output_blob, output_tensor, ort, precision, batch_slice);
   }
 #if defined(OPENVINO_2020_4) || defined(OPENVINO_2021_1)
   if(!const_outputs_map_.empty()){
-    size_t j = i;
     for(auto item : const_outputs_map_){
 
+      auto out_name = item.first;
       auto node = item.second;
-      FillOutputsWithConstantData(ort,node,output_tensors[j]);
-      j++;
+      auto output_tensor = GetOutputTensor(ort, context, out_name, subgraph_context_.output_names, node);
+      FillOutputsWithConstantData(ort,node,output_tensor);
     }
   }
 #endif
@@ -217,21 +162,19 @@ void BasicBackend::Infer(Ort::CustomOpApi& ort, OrtKernelContext* context) {
   LOGS_DEFAULT(INFO) << log_tag << "In Infer";
   std::lock_guard<std::mutex> lock(compute_lock_);
 
-  size_t batch_size = 1;
-  auto output_tensors = GetOutputTensors(ort, context, batch_size, infer_request_, ie_cnn_network_, subgraph_context_.output_names, const_outputs_map_);
   if(subgraph_context_.is_constant){
 #if defined(OPENVINO_2020_4) || defined(OPENVINO_2021_1)
-    size_t i = 0;
     for(auto item : const_outputs_map_){
+      auto out_name = item.first;
       auto node = item.second;
-      FillOutputsWithConstantData(ort,node, output_tensors[i]);
-      i++;
+      auto output_tensor = GetOutputTensor(ort, context, out_name, subgraph_context_.output_names, node);
+      FillOutputsWithConstantData(ort,node, output_tensor);
     }
 #endif
   }
   else{
-    StartAsyncInference(ort, context, infer_request_, ie_cnn_network_);
-    CompleteAsyncInference(ort, output_tensors, infer_request_, ie_cnn_network_);
+    StartAsyncInference(ort, context);
+    CompleteAsyncInference(ort, context);
   }
   // Get Output tensors
   LOGS_DEFAULT(INFO) << log_tag << "Inference successful";

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -22,13 +22,9 @@ class BasicBackend : public IBackend {
   void Infer(Ort::CustomOpApi& ort, OrtKernelContext* context) override;
 
  private:
-  void StartAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context,
-                           InferenceEngine::InferRequest::Ptr infer_request,
-                           std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network);
+  void StartAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context);
 
-  void CompleteAsyncInference(Ort::CustomOpApi& ort, std::vector<OrtValue*> output_tensors,
-                              InferenceEngine::InferRequest::Ptr infer_request,
-                              std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network);
+  void CompleteAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context);
 
   GlobalContext& global_context_;
   SubGraphContext subgraph_context_;

--- a/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/vadm_backend.cc
@@ -1,6 +1,5 @@
 // Copyright(C) 2019 Intel Corporation
 // Licensed under the MIT License
-
 #include <map>
 #include <string>
 #include <memory>
@@ -22,12 +21,6 @@ namespace onnxruntime {
 namespace openvino_ep {
 
 using namespace backend_utils;
-
-struct static_cast_int64
-{
-  template <typename T1> // T1 models type statically convertible to T
-  int64_t operator()(const T1& x) const { return static_cast<int64_t>(x); }
-};
 
 VADMBackend::VADMBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                          GlobalContext& global_context,
@@ -121,15 +114,13 @@ VADMBackend::VADMBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
 // Starts an asynchronous inference request for data in slice indexed by batch_slice_idx on
 // an Infer Request indexed by infer_req_idx
 void VADMBackend::StartAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context,
-                                      size_t batch_slice_idx, size_t infer_req_idx,
-                                      std::vector<InferenceEngine::InferRequest::Ptr>& infer_requests,
-                                      std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network) {
-  auto infer_request = infer_requests[infer_req_idx];
-  auto graph_input_info = ie_cnn_network->getInputsInfo();
+                                      size_t batch_slice_idx, size_t infer_req_idx) {
+  auto infer_request = infer_requests_[infer_req_idx];
+  auto graph_input_info = ie_cnn_network_->getInputsInfo();
 
-  size_t i = 0;
+  size_t index = 0;
   for (auto input_info_iter = graph_input_info.begin();
-       input_info_iter != graph_input_info.end(); ++input_info_iter, ++i) {
+       input_info_iter != graph_input_info.end(); ++input_info_iter, ++index) {
     // Get OpenVINO's input buffer
     InferenceEngine::Blob::Ptr graph_input_blob;
     std::string input_name = input_info_iter->first;
@@ -141,35 +132,7 @@ void VADMBackend::StartAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* c
       ORT_THROW(log_tag + " Cannot access IE Blob for input: " + input_name);
     }
     auto precision = input_info_iter->second->getPrecision();
-    auto graph_input_buffer =
-        graph_input_blob->buffer().as<InferenceEngine::PrecisionTrait<InferenceEngine::Precision::FP32>::value_type*>();
-
-    #if (defined OPENVINO_2020_2) || (defined OPENVINO_2020_3)
-    const OrtValue* tensor = ort.KernelContext_GetInput(context, subgraph_context_.input_indexes[i]);
-    #else
-    const OrtValue* tensor = ort.KernelContext_GetInput(context, subgraph_context_.input_names.at(input_name));
-    #endif
-
-    size_t input_data_size = graph_input_blob->byteSize();
-    auto tensor_shape = ort.GetTensorTypeAndShape(tensor);
-    auto elem_type = ort.GetTensorElementType(tensor_shape);
-
-    if ((elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) &&
-        (precision == InferenceEngine::Precision::I32)) {
-
-      const int64_t* tensor_data_64 = ort.GetTensorData<int64_t>(tensor);
-      auto data_len = (input_data_size * 2) / sizeof(int64_t);
-      const int64_t* batch_memory_offset = tensor_data_64 + data_len * batch_slice_idx;
-
-      std::copy(batch_memory_offset, batch_memory_offset+data_len, (uint32_t*)graph_input_buffer);
-    } else {
-
-      // Copy input data into OpenVINO's input buffer
-      const char* tensor_data = ort.GetTensorData<char>(tensor);
-      const char* batch_memory_offset = tensor_data + input_data_size * batch_slice_idx;
-
-      std::memcpy(graph_input_buffer, batch_memory_offset, input_data_size);
-    }
+    FillInputBlob(graph_input_blob, index, batch_slice_idx, input_name, ort, context, precision, subgraph_context_);
   }
 
   // Start Async inference
@@ -184,11 +147,11 @@ void VADMBackend::StartAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* c
 
 // Wait for asynchronous inference completion on an Infer Request object indexed by infer_req_idx
 // and copy the results into a slice location within the batched output buffer indexed by batch_slice_idx
-void VADMBackend::CompleteAsyncInference(Ort::CustomOpApi& ort, std::vector<OrtValue*> output_tensors,
-                                         size_t batch_slice_idx,
-                                         size_t infer_req_idx, std::vector<InferenceEngine::InferRequest::Ptr>& infer_requests,
-                                         std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network) {
-  auto infer_request = infer_requests[infer_req_idx];
+void VADMBackend::CompleteAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context,
+                                         size_t batch_slice_idx, size_t infer_req_idx,
+                                         size_t batch_size) {
+
+  auto infer_request = infer_requests_[infer_req_idx];
 
   // Wait for Async inference completion
   try {
@@ -198,53 +161,34 @@ void VADMBackend::CompleteAsyncInference(Ort::CustomOpApi& ort, std::vector<OrtV
   } catch (...) {
     ORT_THROW(log_tag + " Exception with completing Inference");
   }
-  auto graph_output_info = ie_cnn_network->getOutputsInfo();
+  auto graph_output_info = ie_cnn_network_->getOutputsInfo();
 
-  size_t i = 0;
   for (auto output_info_iter = graph_output_info.begin();
-       output_info_iter != graph_output_info.end(); ++output_info_iter, ++i) {
+       output_info_iter != graph_output_info.end(); ++output_info_iter) {
     // Get OpenVINO's output blob
     InferenceEngine::Blob::Ptr graph_output_blob;
+    auto output_name = output_info_iter->first;
     try {
-      graph_output_blob = infer_request->GetBlob(output_info_iter->first);
+      graph_output_blob = infer_request->GetBlob(output_name);
     } catch (InferenceEngine::details::InferenceEngineException e) {
-      ORT_THROW(log_tag + " Cannot access IE Blob for output: " + output_info_iter->first + e.what());
+      ORT_THROW(log_tag + " Cannot access IE Blob for output: " + output_name + e.what());
     } catch (...) {
-      ORT_THROW(log_tag + " Cannot access IE Blob for output: " + output_info_iter->first);
+      ORT_THROW(log_tag + " Cannot access IE Blob for output: " + output_name);
     }
-    auto graph_output_buffer =
-        graph_output_blob->buffer().as<InferenceEngine::PrecisionTrait<InferenceEngine::Precision::FP32>::value_type*>();
 
-    size_t output_data_size = graph_output_blob->byteSize();
-    auto tensor_shape = ort.GetTensorTypeAndShape(output_tensors[i]);
-    auto elem_type = ort.GetTensorElementType(tensor_shape);
+    auto output_tensor = GetOutputTensor(ort, context, batch_size, infer_request, output_name, subgraph_context_.output_names);
     auto precision = output_info_iter->second->getPrecision();
 
-   if ((elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) &&
-       (precision == InferenceEngine::Precision::I32)) {
-
-      int64_t* tensor_data = ort.GetTensorMutableData<int64_t>(output_tensors[i]);
-      auto data_len = output_data_size/sizeof(int32_t);
-      int64_t* batch_memory_offset = tensor_data + data_len * batch_slice_idx;
-
-      std::transform((int32_t*)graph_output_buffer,((int32_t*)graph_output_buffer) + data_len, batch_memory_offset, static_cast_int64());
-
-    } else {
-      char* tensor_data = ort.GetTensorMutableData<char>(output_tensors[i]);
-      char* batch_memory_offset = tensor_data + output_data_size * batch_slice_idx;
-
-      // Copy output results back to ONNX-RT's output buffers
-      std::memcpy(batch_memory_offset, graph_output_buffer, output_data_size);
-    }
+    FillOutputBlob(graph_output_blob, output_tensor, ort, precision, batch_slice_idx);
   }
 #if defined(OPENVINO_2020_4)
   if(!const_outputs_map_.empty()){
-    size_t j = i;
     for(auto item : const_outputs_map_){
 
+      auto out_name = item.first;
       auto node = item.second;
-      FillOutputsWithConstantData(ort,node,output_tensors[j]);
-      j++;
+      auto output_tensor = GetOutputTensor(ort, context, out_name, subgraph_context_.output_names, node)
+      FillOutputsWithConstantData(ort,node,output_tensor);
     }
   }
 #endif
@@ -292,17 +236,13 @@ void VADMBackend::Infer(Ort::CustomOpApi& ort, OrtKernelContext* context) {
   size_t full_parallel_runs = batch_size / num_inf_reqs_;
   size_t remainder_parallel_runs = batch_size % num_inf_reqs_;
 
-  // All infer_requests process identical tensor slices from the batch.
-  // So using info from first infer_request to allocate all output tensors.
-  auto output_tensors = GetOutputTensors(ort, context, batch_size, infer_requests_[0], ie_cnn_network_, subgraph_context_.output_names, const_outputs_map_);
-
   if(subgraph_context_.is_constant){
-#if defined(OPENVINO_2020_4)
-    size_t i = 0;
+#if defined(OPENVINO_2020_4) || defined(OPENVINO_2021_1)
     for(auto item : const_outputs_map_){
+      auto out_name = item.first;
       auto node = item.second;
-      FillOutputsWithConstantData(ort,node, output_tensors[i]);
-      i++;
+      auto output_tensor = GetOutputTensor(ort, context, out_name, subgraph_context_.output_names, node);
+      FillOutputsWithConstantData(ort,node, output_tensor);
     }
 #endif
   }
@@ -314,22 +254,22 @@ void VADMBackend::Infer(Ort::CustomOpApi& ort, OrtKernelContext* context) {
     for (size_t set = 0; set < full_parallel_runs; set++) {
       for (size_t inf_req_idx = 0; inf_req_idx < num_inf_reqs_; inf_req_idx++) {
         size_t batch_slice_idx = set * num_inf_reqs_ + inf_req_idx;
-        StartAsyncInference(ort, context, batch_slice_idx, inf_req_idx, infer_requests_, ie_cnn_network_);
+        StartAsyncInference(ort, context, batch_slice_idx, inf_req_idx);
       }
       for (size_t inf_req_idx = 0; inf_req_idx < num_inf_reqs_; inf_req_idx++) {
         size_t batch_slice_idx = set * num_inf_reqs_ + inf_req_idx;
-        CompleteAsyncInference(ort, output_tensors, batch_slice_idx, inf_req_idx, infer_requests_, ie_cnn_network_);
+        CompleteAsyncInference(ort, context, batch_slice_idx, inf_req_idx, batch_size);
       }
     }
 
     // Run parallel inferences for remaining batch slices
     for (size_t inf_req_idx = 0; inf_req_idx < remainder_parallel_runs; inf_req_idx++) {
       size_t batch_slice_idx = full_parallel_runs * num_inf_reqs_ + inf_req_idx;
-      StartAsyncInference(ort, context, batch_slice_idx, inf_req_idx, infer_requests_, ie_cnn_network_);
+      StartAsyncInference(ort, context, batch_slice_idx, inf_req_idx);
     }
     for (size_t inf_req_idx = 0; inf_req_idx < remainder_parallel_runs; inf_req_idx++) {
       size_t batch_slice_idx = full_parallel_runs * num_inf_reqs_ + inf_req_idx;
-      CompleteAsyncInference(ort, output_tensors, batch_slice_idx, inf_req_idx, infer_requests_, ie_cnn_network_);
+      CompleteAsyncInference(ort, context, batch_slice_idx, inf_req_idx, batch_size);
     }
   }
   LOGS_DEFAULT(INFO) << log_tag << "Inference successful";

--- a/onnxruntime/core/providers/openvino/backends/vadm_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/vadm_backend.h
@@ -1,6 +1,5 @@
 // Copyright(C) 2019 Intel Corporation
 // Licensed under the MIT License
-
 #pragma once
 
 #include <memory>
@@ -24,14 +23,11 @@ class VADMBackend : public IBackend {
  private:
   void StartAsyncInference(Ort::CustomOpApi& ort,
                            OrtKernelContext* context,
-                           size_t batch_slice_idx, size_t infer_req_idx,
-                           std::vector<InferenceEngine::InferRequest::Ptr>& infer_requests,
-                           std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network);
+                           size_t batch_slice_idx, size_t infer_req_idx);
 
-  void CompleteAsyncInference(Ort::CustomOpApi& ort, std::vector<OrtValue*> output_tensors,
+  void CompleteAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context,
                               size_t batch_slice_idx, size_t infer_req_idx,
-                              std::vector<InferenceEngine::InferRequest::Ptr>& infer_requests,
-                              std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network);
+                              size_t batch_size);
 
   GlobalContext& global_context_;
   SubGraphContext subgraph_context_;


### PR DESCRIPTION
**Description**: Removed redundant code in backends.

**Motivation and Context**
- Split GetOutputTensors method into two methods one which is for getting output tensor for openvino and second one for getting output of const data
- Added FillInputBlob and FillOutputBlob methods to backend_utils which are then used in Start and Complete AsyncInference calls of both basic backend and vad-m backend.
