### PR TITLE
Maajid/multi threading 2

### DIFF
--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -249,5 +249,4 @@ To use csharp api for openvino execution provider create a custom nuget package.
 
 ## Multi-threading for OpenVINO EP
 
-A pool of 8 usable InferRequests will be made available which may be picked up by any of the threads
-running in parallel to run the Infer() call and perform multi-threaded inference. The choice of how many optimal threads to run in parallel is upto the user and the device that is being used. By Default, only 1 thread would be running during inference.
+OpenVINO Execution Provider enables thread-safe deep learning inference

--- a/docs/execution_providers/OpenVINO-ExecutionProvider.md
+++ b/docs/execution_providers/OpenVINO-ExecutionProvider.md
@@ -246,3 +246,8 @@ Below topologies from ONNX open model zoo are fully supported on OpenVINO Execut
 ## CSharp API
 
 To use csharp api for openvino execution provider create a custom nuget package. Follow the instructions [here](../../BUILD.md##build-nuget-packages) to install prerequisites for nuget creation. Once prerequisites are installed follow the instructions to [build openvino](../../BUILD.md#openvino) and add an extra flag `--build_nuget` to create nuget packages. Two nuget packages will be created Microsoft.ML.OnnxRuntime.Managed and Microsoft.ML.OnnxRuntime.Openvino.
+
+## Multi-threading for OpenVINO EP
+
+A pool of 8 usable InferRequests will be made available which may be picked up by any of the threads
+running in parallel to run the Infer() call and perform multi-threaded inference. The choice of how many optimal threads to run in parallel is upto the user and the device that is being used. By Default, only 1 thread would be running during inference.

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -66,7 +66,7 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
 
   //Initializing the infer_requests_ pool with 8 infer_request's (creating infer_request)
   size_t nireq = 8;
-  inferRequestsQueue = std::unique_ptr<InferRequestsQueue>(new InferRequestsQueue(exe_network, nireq));
+  inferRequestsQueue_ = std::unique_ptr<InferRequestsQueue>(new InferRequestsQueue(exe_network, nireq));
 }
 
 // Starts an asynchronous inference request for data in slice indexed by batch_slice_idx on
@@ -153,7 +153,7 @@ void BasicBackend::Infer(Ort::CustomOpApi& ort, OrtKernelContext* context) {
   // currently allows a maximum of 8 Infer request's to paralelly execute at the same time
 
   //Requesting for an idle infer_request from a pool of infer_requests_
-  std::shared_ptr<InferenceEngine::InferRequest> infer_request = inferRequestsQueue->getIdleRequest();
+  std::shared_ptr<InferenceEngine::InferRequest> infer_request = inferRequestsQueue_->getIdleRequest();
   if (!infer_request) {
     LOGS_DEFAULT(INFO) << "No idle Infer Requests found from the infer_requests_ pool!";
     THROW_IE_EXCEPTION << "No idle Infer Requests!";
@@ -179,9 +179,9 @@ void BasicBackend::Infer(Ort::CustomOpApi& ort, OrtKernelContext* context) {
   // Get Output tensors
   LOGS_DEFAULT(INFO) << log_tag << "Inference successful";
   //Once the inference is completed, the infer_request becomes free and is placed back into pool of infer_requests_
-  inferRequestsQueue->putIdleRequest(infer_request); 
+  inferRequestsQueue_->putIdleRequest(infer_request); 
 #ifndef NDEBUG
-  inferRequestsQueue->printstatus(); //Printing the elements of infer_requests_ vector pool only in debug mode
+  inferRequestsQueue_->printstatus(); //Printing the elements of infer_requests_ vector pool only in debug mode
 #endif
 }
 

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -181,7 +181,9 @@ void BasicBackend::Infer(Ort::CustomOpApi& ort, OrtKernelContext* context) {
   //Once the inference is completed, the infer_request becomes free and is placed back into pool of infer_requests_
   inferRequestsQueue_->putIdleRequest(infer_request); 
 #ifndef NDEBUG
-  inferRequestsQueue_->printstatus(); //Printing the elements of infer_requests_ vector pool only in debug mode
+  if (openvino_ep::backend_utils::IsDebugEnabled()) {
+      inferRequestsQueue_->printstatus(); //Printing the elements of infer_requests_ vector pool only in debug mode
+  }
 #endif
 }
 

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -10,6 +10,12 @@
 #include "core/providers/openvino/contexts.h"
 #include "core/providers/openvino/ibackend.h"
 
+#include <vector>
+#include <queue>
+#include <string>
+#include <condition_variable>
+#include <mutex>
+
 namespace onnxruntime {
 namespace openvino_ep {
 
@@ -32,6 +38,51 @@ class BasicBackend : public IBackend {
   std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network_;
   std::map<std::string, std::shared_ptr<ngraph::Node>> const_outputs_map_;
   InferenceEngine::InferRequest::Ptr infer_request_;
+  InferenceEngine::ExecutableNetwork exe_network;
 };
+
+class InferRequestsQueue {
+public:
+InferRequestsQueue(InferenceEngine::ExecutableNetwork& net, size_t nireq) {
+  for (size_t id = 0; id < nireq; id++) {
+      infer_request_ = net.CreateInferRequestPtr();
+      infer_requests_.push_back(infer_request_);
+    }
+  }
+
+~InferRequestsQueue() {
+  std::cout << "calling out the ~InferRequestsQueue() Destructor " << std::endl;
+}
+
+void printstatus() {
+    std::cout << "printing elements of the vector (infer_requests_): " << std::endl;
+    for (auto i = infer_requests_.begin(); i != infer_requests_.end(); ++i)
+    {
+        std::cout << *i << " ";
+    }
+        std::cout << '\n';
+}
+
+void putIdleRequest(InferenceEngine::InferRequest::Ptr infer_request_) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    infer_requests_.push_back(infer_request_);
+    _cv.notify_one();
+}
+
+InferenceEngine::InferRequest::Ptr getIdleRequest() {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _cv.wait(lock, [this]{ return infer_requests_.size() > 0; });
+    auto request = infer_requests_.at(0);
+    infer_requests_.erase(infer_requests_.begin());
+    return request;
+}
+
+private:
+std::mutex _mutex;
+std::condition_variable _cv;
+std::vector<InferenceEngine::InferRequest::Ptr> infer_requests_;
+InferenceEngine::InferRequest::Ptr infer_request_;
+};
+
 }  // namespace openvino_ep
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -37,7 +37,7 @@ class BasicBackend : public IBackend {
   mutable std::mutex compute_lock_;
   std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network_;
   std::map<std::string, std::shared_ptr<ngraph::Node>> const_outputs_map_;
-  std::unique_ptr<InferRequestsQueue> inferRequestsQueue;
+  std::unique_ptr<InferRequestsQueue> inferRequestsQueue_;
 };
 
 class InferRequestsQueue {

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -11,7 +11,6 @@
 #include "core/providers/openvino/ibackend.h"
 
 #include <vector>
-#include <queue>
 #include <string>
 #include <condition_variable>
 #include <mutex>
@@ -51,16 +50,18 @@ InferRequestsQueue(InferenceEngine::ExecutableNetwork& net, size_t nireq) {
   }
 
 ~InferRequestsQueue() {
-  std::cout << "calling out the ~InferRequestsQueue() Destructor " << std::endl;
+  // clearing out the infer_requests_ vector pool in the class's destructor
+  for(auto& pointer : infer_requests_) {
+       pointer = nullptr;
+   }
+  infer_requests_.erase(std::remove(infer_requests_.begin(), infer_requests_.end(), nullptr), infer_requests_.end());
 }
 
 void printstatus() {
     std::cout << "printing elements of the vector (infer_requests_): " << std::endl;
-    for (auto i = infer_requests_.begin(); i != infer_requests_.end(); ++i)
-    {
-        std::cout << *i << " ";
+    for (auto i = infer_requests_.begin(); i != infer_requests_.end(); ++i) {
+        std::cout << *i << " " << '\n';
     }
-        std::cout << '\n';
 }
 
 void putIdleRequest(InferenceEngine::InferRequest::Ptr infer_request_) {

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -43,6 +43,7 @@ class BasicBackend : public IBackend {
 class InferRequestsQueue {
 public:
 InferRequestsQueue(InferenceEngine::ExecutableNetwork& net, size_t nireq) {
+  InferenceEngine::InferRequest::Ptr infer_request_;
   for (size_t id = 0; id < nireq; id++) {
       infer_request_ = net.CreateInferRequestPtr();
       infer_requests_.push_back(infer_request_);
@@ -83,7 +84,6 @@ private:
 std::mutex _mutex;
 std::condition_variable _cv;
 std::vector<InferenceEngine::InferRequest::Ptr> infer_requests_;
-InferenceEngine::InferRequest::Ptr infer_request_;
 };
 
 }  // namespace openvino_ep

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -19,6 +19,7 @@
 namespace onnxruntime {
 namespace openvino_ep {
 
+class InferRequestsQueue;
 class BasicBackend : public IBackend {
  public:
   BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
@@ -37,8 +38,9 @@ class BasicBackend : public IBackend {
   mutable std::mutex compute_lock_;
   std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network_;
   std::map<std::string, std::shared_ptr<ngraph::Node>> const_outputs_map_;
-  InferenceEngine::InferRequest::Ptr infer_request_;
+  std::shared_ptr<InferenceEngine::InferRequest> infer_request_;
   InferenceEngine::ExecutableNetwork exe_network;
+  std::unique_ptr<InferRequestsQueue> inferRequestsQueue;
 };
 
 class InferRequestsQueue {

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -29,17 +29,15 @@ class BasicBackend : public IBackend {
   void Infer(Ort::CustomOpApi& ort, OrtKernelContext* context) override;
 
  private:
-  void StartAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context);
+  void StartAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context, std::shared_ptr<InferenceEngine::InferRequest> infer_request);
 
-  void CompleteAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context);
+  void CompleteAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context, std::shared_ptr<InferenceEngine::InferRequest> infer_request);
 
   GlobalContext& global_context_;
   SubGraphContext subgraph_context_;
   mutable std::mutex compute_lock_;
   std::shared_ptr<InferenceEngine::CNNNetwork> ie_cnn_network_;
   std::map<std::string, std::shared_ptr<ngraph::Node>> const_outputs_map_;
-  std::shared_ptr<InferenceEngine::InferRequest> infer_request_;
-  InferenceEngine::ExecutableNetwork exe_network;
   std::unique_ptr<InferRequestsQueue> inferRequestsQueue;
 };
 

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -60,8 +60,9 @@ InferRequestsQueue(InferenceEngine::ExecutableNetwork& net, size_t nireq) {
 void printstatus() {
     std::cout << "printing elements of the vector (infer_requests_): " << std::endl;
     for (auto i = infer_requests_.begin(); i != infer_requests_.end(); ++i) {
-        std::cout << *i << " " << '\n';
+        std::cout << *i << " ";
     }
+    std::cout << '\n';
 }
 
 void putIdleRequest(InferenceEngine::InferRequest::Ptr infer_request_) {

--- a/onnxruntime/test/perftest/main.cc
+++ b/onnxruntime/test/perftest/main.cc
@@ -41,17 +41,6 @@ int real_main(int argc, char* argv[]) {
     if (failed)
       return -1;
   }
-
-  if (test_config.machine_config.provider_type_name == onnxruntime::kOpenVINOExecutionProvider) {
-    if (test_config.run_config.concurrent_session_runs != 1) {
-      fprintf(stderr, "OpenVINO doesn't support more than 1 session running simultaneously default value of 1 will be set \n");
-      test_config.run_config.concurrent_session_runs = 1;
-    }
-    if (test_config.run_config.execution_mode == ExecutionMode::ORT_PARALLEL) {
-      fprintf(stderr, "OpenVINO doesn't support parallel executor using sequential executor\n");
-      test_config.run_config.execution_mode = ExecutionMode::ORT_SEQUENTIAL;
-    }
-  }
   std::random_device rd;
   perftest::PerformanceRunner perf_runner(env, test_config, rd);
   auto status = perf_runner.Run();


### PR DESCRIPTION
**Description**: 
Enabling Multi-threading for OpenVINO EP

**Motivation and Context**
Currently we were just supporting single threaded inference. With Multi Threaded inference we would
be able to reduce the total inference run time as multiple threads would be able to parallelly execute now.

A pool of 8 usable InferRequests will be made available which may be picked up by any of the threads
running in parallel to run the Infer() call and perform multi-threaded inference. The choice of how many optimal threads to run in parallel depends on the HW device that is being used. By Default, only 1 thread would be running during inference unless
specified to use multiple threads.

we were able to see significant change with the overall inference time with multi threading enabled.

