### PR TITLE
[OpenVINO-EP] Fix RelWithDebInfo build issue on windows

### DIFF
--- a/cmake/onnxruntime_providers.cmake
+++ b/cmake/onnxruntime_providers.cmake
@@ -576,6 +576,10 @@ if (onnxruntime_USE_OPENVINO)
     "${ONNXRUNTIME_ROOT}/core/providers/shared_library/*.cc"
   )
 
+  if (WIN32)
+	  set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
+  endif()
+
   # Header paths
   find_package(InferenceEngine REQUIRED)
   find_package(ngraph REQUIRED)


### PR DESCRIPTION
**Description**: Fix RelWithDebInfo build for windows

**Motivation and Context**
The RelWithDebInfo build was not able to locate ngraph and inference engine libraries on windows.
A fix has been added to fix this bug.