### PR TITLE
Add command to skip tests

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1978,6 +1978,10 @@ def main():
     if args.use_openvino == "VAD-F_FP32":
         args.test = False
 
+    # Disabling unit tests for GPU and MYRIAD on nuget creation
+    if args.use_openvino != "CPU_FP32" and args.build_nuget:
+        args.test = False
+
     configs = set(args.config)
 
     # setup paths and directories


### PR DESCRIPTION
Skip unit tests when building nuget packages for Myriad and GPU

**Motivation and Context**
-This change was required because the failed tests cases were not helping the nugets to build. 
- If it fixes an open issue, please link to the issue here.
