### PR TITLE
[OpenVINO-EP] Fixing Yolo models for wider operator coverage for all devices 

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -98,6 +98,7 @@ std::vector<SupportedOp> supported_op_mode = {
     {"Gather", V_2020_4, {"All"}},
     {"GatherElements", V_2021_3, {"MYRIAD"}},
     {"GatherND", V_2021_2, {"MYRIAD"}},
+    {"GatherND", V_2021_4, {"All"}},
     {"Gemm", V_2020_4, {"All"}},
     {"GlobalAveragePool", V_2020_4, {"All"}},
     {"GlobalLpPool", V_2020_4, {"CPU", "GPU"}},

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -419,10 +419,6 @@ void DataOps::populate_op_mode_supported() {
                                const auto& attributes = node->GetAttributes();
                                auto out_shape_attr = attributes.find("output_shape");
 
-                               //tensor type does not support output_shape in Attributes
-                               if (out_shape_attr != attributes.end())
-                                  return true;
-
                                // If the device is GPU
                                if (device_id_.find("GPU") != std::string::npos) {
                                  auto conv_filter = attributes.find("kernel_shape");

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -102,6 +102,7 @@ std::vector<SupportedOp> supported_op_mode = {
     {"GlobalLpPool", V_2020_4, {"CPU", "GPU"}},
     {"Greater", V_2020_4, {"All"}},
     {"Identity", V_2020_4, {"All"}},
+    {"ImageScaler", V_2021_4, {"All"}},
     {"InstanceNormalization", V_2020_4, {"All"}},
     {"HardSigmoid", V_2020_4, {"CPU", "GPU"}},
     {"LeakyRelu", V_2020_4, {"All"}},

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -75,6 +75,7 @@ std::vector<SupportedOp> supported_op_mode = {
     {"Ceil", V_2020_4, {"GPU"}},
     {"Ceil", V_2021_3, {"MYRIAD"}},
     {"Ceil", V_2021_2, {"GPU", "MYRIAD"}},
+    {"Ceil", V_2021_4, {"All"}},
     {"Clip", V_2020_4, {"All"}},
     {"Concat", V_2020_4, {"All"}},
     {"Constant", V_2020_4, {"All"}},
@@ -109,6 +110,7 @@ std::vector<SupportedOp> supported_op_mode = {
     {"Less", V_2020_4, {"All"}},
     {"Log", V_2020_4, {"All"}},
     {"Loop", V_2021_3, {"MYRIAD"}},
+    {"Loop", V_2021_4, {"All"}},
     {"LRN", V_2020_4, {"All"}},
     {"LSTM", V_2020_4, {"All"}},
     {"MatMul", V_2020_4, {"All"}},
@@ -163,6 +165,7 @@ std::vector<SupportedOp> supported_op_mode = {
     {"Tan", V_2020_4, {"CPU", "GPU"}},
     {"Tanh", V_2020_4, {"All"}},
     {"Tile", V_2021_3, {"MYRIAD"}},
+    {"Tile", V_2021_3, {"All"}},
     {"Transpose", V_2020_4, {"All"}},
     {"TopK", V_2020_4, {"All"}},
     {"Unsqueeze", V_2020_4, {"All"}},
@@ -247,8 +250,11 @@ void DataOps::populate_op_mode_supported() {
   no_dimension_supported_.push_back({"Equal", V_2021_2, {"MYRIAD"}});
   no_dimension_supported_.push_back({"Reshape", V_2021_3, {"MYRIAD"}});
   no_dimension_supported_.push_back({"Ceil", V_2021_3, {"MYRIAD"}});
+  no_dimension_supported_.push_back({"Ceil", V_2021_4, {"All"}});
   no_dimension_supported_.push_back({"Loop", V_2021_3, {"MYRIAD"}});
+  no_dimension_supported_.push_back({"Loop", V_2021_4, {"All"}});
   no_dimension_supported_.push_back({"ReduceMin", V_2021_3, {"MYRIAD"}});
+  no_dimension_supported_.push_back({"ReduceMin", V_2021_4, {"All"}});
   no_dimension_supported_.push_back({"QuantizeLinear", V_2021_4, {"All"}});
   no_dimension_supported_.push_back({"DequantizeLinear", V_2021_4, {"All"}});
   

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -144,6 +144,7 @@ std::vector<SupportedOp> supported_op_mode = {
     {"Reshape", V_2020_4, {"All"}},
     {"RoiAlign", V_2021_1, {"All"}},
     {"Round", V_2021_2, {"MYRIAD"}},
+    {"Round", V_2021_4, {"All"}},
     {"Scatter", V_2021_1, {"MYRIAD"}},
     {"ScatterElements", V_2021_2, {"MYRIAD"}},
     {"Selu", V_2020_4, {"CPU", "GPU"}},

--- a/onnxruntime/test/providers/cpu/nn/conv_transpose_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_transpose_op_test.cc
@@ -255,7 +255,8 @@ TEST(ConvTransposeTest, ConvTranspose_2D_OutputShape_1) {
                         18.0f, 27.0f, 27.0f, 18.0f,
                         18.0f, 27.0f, 27.0f, 18.0f,
                         12.0f, 18.0f, 18.0f, 12.0f};
-  TestConvTransposeOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
+  TestConvTransposeOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape,
+                      OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
 }
 
 TEST(ConvTransposeTest, ConvTranspose_2D_OutputShape_1_group_2_for_tranpose_path) {
@@ -382,7 +383,8 @@ TEST(ConvTransposeTest, ConvTranspose_2D_OutputShape_1_group_2_for_tranpose_path
       18.0f,
       12.0f,
   };
-  TestConvTransposeOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
+  TestConvTransposeOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape,
+                      OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
 }
 
 TEST(ConvTransposeTest, ConvTranspose_2D_OutputShape_2) {
@@ -404,7 +406,8 @@ TEST(ConvTransposeTest, ConvTranspose_2D_OutputShape_2) {
   vector<int64_t> B_shape = {1};
   vector<int64_t> Y_shape = {1, 1, 1, 14};
   auto expected_vals = {1.0f, 2.0f, 5.0f, 11.0f, 19.0f, 28.0f, 37.0f, 46.0f, 55.0f, 64.0f, 63.0f, 51.0f, 27.0f, 10.0f};
-  TestConvTransposeOp(attrs, {X, W, B}, {X_shape, W_shape, B_shape}, expected_vals, Y_shape);
+  TestConvTransposeOp(attrs, {X, W, B}, {X_shape, W_shape, B_shape}, expected_vals, Y_shape,
+                      OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
 }
 
 TEST(ConvTransposeTest, ConvTranspose_2D_OutputShapeWithBatchSize) {
@@ -428,7 +431,8 @@ TEST(ConvTransposeTest, ConvTranspose_2D_OutputShapeWithBatchSize) {
   vector<int64_t> Y_shape = {2, 1, 1, 14};
   auto expected_vals = {1.0f, 2.0f, 5.0f, 11.0f, 19.0f, 28.0f, 37.0f, 46.0f, 55.0f, 64.0f, 63.0f, 51.0f, 27.0f, 10.0f,
                         11.0f, 32.0f, 65.0f, 91.0f, 109.0f, 118.0f, 127.0f, 136.0f, 145.0f, 154.0f, 143.0f, 111.0f, 57.0f, 20.0f};
-  TestConvTransposeOp(attrs, {X, W, B}, {X_shape, W_shape, B_shape}, expected_vals, Y_shape);
+  TestConvTransposeOp(attrs, {X, W, B}, {X_shape, W_shape, B_shape}, expected_vals, Y_shape,
+                      OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
 }
 
 TEST(ConvTransposeTest, ConvTranspose_InvalidKernelShape) {


### PR DESCRIPTION
**Description**: Fixing yolo models for wider operators coverage

**Motivation and Context**
- Make the models fully supported on OpenVINO-EP
- Try to reduce the number of subgraphs if the model can't be fully supported on OV-EP
- Analysis the status for cpu/gpu/vpu
- Models Analyzed and fixed.
test_tiny_yolo_v2, tiny_yolo_v2, yolov3, tiny_yolov3, yolov3_pytorch, yolov4, yolov5s
