### PR TITLE
Enable OpenCL Throttling for GPU Device

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -500,7 +500,7 @@ typedef struct OrtMIGraphXProviderOptions {
 */
 typedef struct OrtOpenVINOProviderOptions {
 #ifdef __cplusplus
-  OrtOpenVINOProviderOptions() : device_type{}, enable_vpu_fast_compile{}, device_id{}, num_of_threads{}, use_compiled_network{}, blob_dump_path{}, context{} {}
+  OrtOpenVINOProviderOptions() : device_type{}, enable_vpu_fast_compile{}, device_id{}, num_of_threads{}, use_compiled_network{}, blob_dump_path{}, context{}, enable_gpu_throttling{} {}
 #endif
   /** \brief Device type string
   *
@@ -513,6 +513,7 @@ typedef struct OrtOpenVINOProviderOptions {
   unsigned char use_compiled_network;  ///< 0 = disabled, nonzero = enabled
   const char* blob_dump_path;          // path is set to empty by default
   void* context;
+  unsigned char enable_gpu_throttling; ///< 0 = disabled, nonzero = enabled
 } OrtOpenVINOProviderOptions;
 
 struct OrtApi;

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -500,7 +500,7 @@ typedef struct OrtMIGraphXProviderOptions {
 */
 typedef struct OrtOpenVINOProviderOptions {
 #ifdef __cplusplus
-  OrtOpenVINOProviderOptions() : device_type{}, enable_vpu_fast_compile{}, device_id{}, num_of_threads{}, use_compiled_network{}, blob_dump_path{}, context{}, enable_gpu_throttling{} {}
+  OrtOpenVINOProviderOptions() : device_type{}, enable_vpu_fast_compile{}, device_id{}, num_of_threads{}, use_compiled_network{}, blob_dump_path{}, context{}, enable_opencl_throttling{} {}
 #endif
   /** \brief Device type string
   *
@@ -513,7 +513,7 @@ typedef struct OrtOpenVINOProviderOptions {
   unsigned char use_compiled_network;  ///< 0 = disabled, nonzero = enabled
   const char* blob_dump_path;          // path is set to empty by default
   void* context;
-  unsigned char enable_gpu_throttling; ///< 0 = disabled, nonzero = enabled
+  unsigned char enable_opencl_throttling; ///< 0 = disabled, nonzero = enabled
 } OrtOpenVINOProviderOptions;
 
 struct OrtApi;

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -101,8 +101,16 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
     } else {
       cache_dir_path = global_context_.blob_dump_path;
     }
+    LOGS_DEFAULT(INFO) << log_tag << "Enables Caching";
     global_context_.ie_core.SetConfig({{CONFIG_KEY(CACHE_DIR), cache_dir_path}});
   }
+
+  //Setting GPU Plugin throttle
+  if (global_context_.enable_gpu_throttling == true && global_context_.device_type.find("GPU") != std::string::npos) {
+    LOGS_DEFAULT(INFO) << log_tag << "Enabled GPU Plugin Throttle";
+    config[GPU_CONFIG_KEY(PLUGIN_THROTTLE)] = "1";
+  }
+
   try {
     #if defined(IO_BUFFER_ENABLED)
       if ((global_context.device_type.find("GPU") != std::string::npos)  && 

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -105,9 +105,9 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
     global_context_.ie_core.SetConfig({{CONFIG_KEY(CACHE_DIR), cache_dir_path}});
   }
 
-  //Setting GPU Plugin throttle
-  if (global_context_.enable_gpu_throttling == true && global_context_.device_type.find("GPU") != std::string::npos) {
-    LOGS_DEFAULT(INFO) << log_tag << "Enabled GPU Plugin Throttle";
+  //Setting OpenCL queue throttling for GPU
+  if (global_context_.enable_opencl_throttling == true && global_context_.device_type.find("GPU") != std::string::npos) {
+    LOGS_DEFAULT(INFO) << log_tag << "Enabled OpenCL queue throttling for GPU device";
     config[GPU_CONFIG_KEY(PLUGIN_THROTTLE)] = "1";
   }
 

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -14,6 +14,7 @@ struct GlobalContext {
   bool is_wholly_supported_graph = false;
   bool enable_vpu_fast_compile = false;
   bool use_compiled_network = false;
+  bool enable_gpu_throttling = false;
   size_t num_of_threads;
   std::string device_type;
   std::string precision_str;

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -14,7 +14,7 @@ struct GlobalContext {
   bool is_wholly_supported_graph = false;
   bool enable_vpu_fast_compile = false;
   bool use_compiled_network = false;
-  bool enable_gpu_throttling = false;
+  bool enable_opencl_throttling = false;
   size_t num_of_threads;
   std::string device_type;
   std::string precision_str;

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -19,6 +19,8 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProv
   openvino_ep::BackendManager::GetGlobalContext().use_compiled_network = info.use_compiled_network_;
   openvino_ep::BackendManager::GetGlobalContext().blob_dump_path = info.blob_dump_path_;
   openvino_ep::BackendManager::GetGlobalContext().context = info.context_;
+  openvino_ep::BackendManager::GetGlobalContext().enable_gpu_throttling = info.enable_gpu_throttling_;
+
 
   if ((int)info.num_of_threads_ <= 0) {
     openvino_ep::BackendManager::GetGlobalContext().num_of_threads = 8;

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -19,7 +19,7 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProv
   openvino_ep::BackendManager::GetGlobalContext().use_compiled_network = info.use_compiled_network_;
   openvino_ep::BackendManager::GetGlobalContext().blob_dump_path = info.blob_dump_path_;
   openvino_ep::BackendManager::GetGlobalContext().context = info.context_;
-  openvino_ep::BackendManager::GetGlobalContext().enable_gpu_throttling = info.enable_gpu_throttling_;
+  openvino_ep::BackendManager::GetGlobalContext().enable_opencl_throttling = info.enable_opencl_throttling_;
 
 
   if ((int)info.num_of_threads_ <= 0) {

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -59,9 +59,10 @@ struct OpenVINOExecutionProviderInfo {
   bool use_compiled_network_;
   std::string blob_dump_path_;
   void* context_;
+  bool enable_gpu_throttling_;
 
-  explicit OpenVINOExecutionProviderInfo(std::string dev_type, bool enable_vpu_fast_compile, std::string dev_id, size_t num_of_threads, bool use_compiled_network, std::string blob_dump_path, void* context)
-      : enable_vpu_fast_compile_(enable_vpu_fast_compile), device_id_(dev_id), num_of_threads_(num_of_threads), use_compiled_network_(use_compiled_network), blob_dump_path_(blob_dump_path), context_(context) {
+  explicit OpenVINOExecutionProviderInfo(std::string dev_type, bool enable_vpu_fast_compile, std::string dev_id, size_t num_of_threads, bool use_compiled_network, std::string blob_dump_path, void* context, bool enable_gpu_throttling)
+      : enable_vpu_fast_compile_(enable_vpu_fast_compile), device_id_(dev_id), num_of_threads_(num_of_threads), use_compiled_network_(use_compiled_network), blob_dump_path_(blob_dump_path), context_(context), enable_gpu_throttling_(enable_gpu_throttling) {
     if (dev_type == "") {
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
                          << "No runtime device selection option provided.";
@@ -129,7 +130,7 @@ struct OpenVINOExecutionProviderInfo {
                        << "Choosing Device: " << device_type_ << " , Precision: " << precision_;
   }
   OpenVINOExecutionProviderInfo() {
-    OpenVINOExecutionProviderInfo("", false, "", 0, false,"", NULL);
+    OpenVINOExecutionProviderInfo("", false, "", 0, false,"", NULL, false);
   }
 };
 

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -59,10 +59,10 @@ struct OpenVINOExecutionProviderInfo {
   bool use_compiled_network_;
   std::string blob_dump_path_;
   void* context_;
-  bool enable_gpu_throttling_;
+  bool enable_opencl_throttling_;
 
-  explicit OpenVINOExecutionProviderInfo(std::string dev_type, bool enable_vpu_fast_compile, std::string dev_id, size_t num_of_threads, bool use_compiled_network, std::string blob_dump_path, void* context, bool enable_gpu_throttling)
-      : enable_vpu_fast_compile_(enable_vpu_fast_compile), device_id_(dev_id), num_of_threads_(num_of_threads), use_compiled_network_(use_compiled_network), blob_dump_path_(blob_dump_path), context_(context), enable_gpu_throttling_(enable_gpu_throttling) {
+  explicit OpenVINOExecutionProviderInfo(std::string dev_type, bool enable_vpu_fast_compile, std::string dev_id, size_t num_of_threads, bool use_compiled_network, std::string blob_dump_path, void* context, bool enable_opencl_throttling)
+      : enable_vpu_fast_compile_(enable_vpu_fast_compile), device_id_(dev_id), num_of_threads_(num_of_threads), use_compiled_network_(use_compiled_network), blob_dump_path_(blob_dump_path), context_(context), enable_opencl_throttling_(enable_opencl_throttling) {
     if (dev_type == "") {
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
                          << "No runtime device selection option provided.";

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -10,8 +10,8 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
   OpenVINOProviderFactory(const char* device_type, bool enable_vpu_fast_compile,
                           const char* device_id, size_t num_of_threads,
                           bool use_compiled_network, const char* blob_dump_path, void* context,
-                          bool enable_gpu_throttling)
-      : enable_vpu_fast_compile_(enable_vpu_fast_compile), num_of_threads_(num_of_threads), use_compiled_network_(use_compiled_network), context_(context), enable_gpu_throttling_(enable_gpu_throttling) {
+                          bool enable_opencl_throttling)
+      : enable_vpu_fast_compile_(enable_vpu_fast_compile), num_of_threads_(num_of_threads), use_compiled_network_(use_compiled_network), context_(context), enable_opencl_throttling_(enable_opencl_throttling) {
     device_type_ = (device_type == nullptr) ? "" : device_type;
     device_id_ = (device_id == nullptr) ? "" : device_id;
     blob_dump_path_ = (blob_dump_path == nullptr) ? "" : blob_dump_path;
@@ -29,17 +29,17 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
   bool use_compiled_network_;
   std::string blob_dump_path_;
   void *context_; 
-  bool enable_gpu_throttling_;
+  bool enable_opencl_throttling_;
 };
 
 std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {
-  OpenVINOExecutionProviderInfo info(device_type_, enable_vpu_fast_compile_, device_id_, num_of_threads_, use_compiled_network_, blob_dump_path_, context_, enable_gpu_throttling_);
+  OpenVINOExecutionProviderInfo info(device_type_, enable_vpu_fast_compile_, device_id_, num_of_threads_, use_compiled_network_, blob_dump_path_, context_, enable_opencl_throttling_);
   return std::make_unique<OpenVINOExecutionProvider>(info);
 }
 
 std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory_OpenVINO(
-    const char* device_type, bool enable_vpu_fast_compile, const char* device_id, size_t num_of_threads, bool use_compiled_network, const char* blob_dump_path, void * context, bool enable_gpu_throttling) {
-  return std::make_shared<onnxruntime::OpenVINOProviderFactory>(device_type, enable_vpu_fast_compile, device_id, num_of_threads, use_compiled_network, blob_dump_path, context, enable_gpu_throttling);
+    const char* device_type, bool enable_vpu_fast_compile, const char* device_id, size_t num_of_threads, bool use_compiled_network, const char* blob_dump_path, void * context, bool enable_opencl_throttling) {
+  return std::make_shared<onnxruntime::OpenVINOProviderFactory>(device_type, enable_vpu_fast_compile, device_id, num_of_threads, use_compiled_network, blob_dump_path, context, enable_opencl_throttling);
 }
 
 }  // namespace onnxruntime
@@ -57,7 +57,7 @@ struct OpenVINO_Provider : Provider {
 
   std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory(const void* void_params) override {
     auto& params = *reinterpret_cast<const OrtOpenVINOProviderOptions*>(void_params);
-    return std::make_shared<OpenVINOProviderFactory>(params.device_type, params.enable_vpu_fast_compile, params.device_id, params.num_of_threads, params.use_compiled_network, params.blob_dump_path, params.context, params.enable_gpu_throttling);
+    return std::make_shared<OpenVINOProviderFactory>(params.device_type, params.enable_vpu_fast_compile, params.device_id, params.num_of_threads, params.use_compiled_network, params.blob_dump_path, params.context, params.enable_opencl_throttling);
   }
 
   void Shutdown() override {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -594,6 +594,14 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
             ORT_THROW("Invalid value passed for use_compiled_network: ", option.second);
           }
 
+        } else if (option.first == "enable_gpu_throttling") {
+          if (option.second == "True") {
+            params.use_compiled_network = true;
+          } else if (option.second == "False") {
+            params.use_compiled_network = false;
+          } else {
+            ORT_THROW("Invalid value passed for enable_gpu_throttling: ", option.second);
+          }
         } else if (option.first == "device_id") {
           params.device_id = option.second.c_str();
         } else if (option.first == "num_of_threads") {

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -594,13 +594,13 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
             ORT_THROW("Invalid value passed for use_compiled_network: ", option.second);
           }
 
-        } else if (option.first == "enable_gpu_throttling") {
+        } else if (option.first == "enable_opencl_throttling") {
           if (option.second == "True") {
             params.use_compiled_network = true;
           } else if (option.second == "False") {
             params.use_compiled_network = false;
           } else {
-            ORT_THROW("Invalid value passed for enable_gpu_throttling: ", option.second);
+            ORT_THROW("Invalid value passed for enable_opencl_throttling: ", option.second);
           }
         } else if (option.first == "device_id") {
           params.device_id = option.second.c_str();

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -62,7 +62,7 @@ namespace perftest {
       "\t    [OpenVINO only] [num_of_threads]: Overrides the accelerator hardware type and precision with these values at runtime.\n"
       "\t    [OpenVINO only] [use_compiled_network]: Can be enabled to directly import pre-compiled blobs(VPU) or cl_cache files(iGPU) if exists else dump one. This feature is supported on MyriadX(VPU) hardware device target. Starting from OpenVINO 2021.4 version, this feature also works with iGPU with cl_cache.\n"
       "\t    [OpenVINO only] [blob_dump_path]: Explicitly specify the path where you would like to dump and load the blobs or cl_cache files for the use_compiled_network(Model caching) feature. This overrides the default path.\n"
-      "\t    [OpenVINO only] [enable_gpu_throttling]: Enables GPU Throttling (Reduces the CPU Utilization while using GPU) \n"
+      "\t    [OpenVINO only] [enable_opencl_throttling]: Enables OpenCL queue throttling for GPU device(Reduces the CPU Utilization while using GPU) \n"
       "\t [Usage]: -e <provider_name> -i '<key1>|<value1> <key2>|<value2>'\n\n"
       "\t [Example] [For OpenVINO EP] -e openvino -i \"device_type|CPU_FP32 enable_vpu_fast_compile|true num_of_threads|5 use_compiled_network|true blob_dump_path|\"<path>\"\"\n"
       "\t    [TensorRT only] [trt_max_partition_iterations]: Maximum iterations for TensorRT parser to get capability.\n"

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -62,6 +62,7 @@ namespace perftest {
       "\t    [OpenVINO only] [num_of_threads]: Overrides the accelerator hardware type and precision with these values at runtime.\n"
       "\t    [OpenVINO only] [use_compiled_network]: Can be enabled to directly import pre-compiled blobs(VPU) or cl_cache files(iGPU) if exists else dump one. This feature is supported on MyriadX(VPU) hardware device target. Starting from OpenVINO 2021.4 version, this feature also works with iGPU with cl_cache.\n"
       "\t    [OpenVINO only] [blob_dump_path]: Explicitly specify the path where you would like to dump and load the blobs or cl_cache files for the use_compiled_network(Model caching) feature. This overrides the default path.\n"
+      "\t    [OpenVINO only] [enable_gpu_throttling]: Enables GPU Throttling (Reduces the CPU Utilization while using GPU) \n"
       "\t [Usage]: -e <provider_name> -i '<key1>|<value1> <key2>|<value2>'\n\n"
       "\t [Example] [For OpenVINO EP] -e openvino -i \"device_type|CPU_FP32 enable_vpu_fast_compile|true num_of_threads|5 use_compiled_network|true blob_dump_path|\"<path>\"\"\n"
       "\t    [TensorRT only] [trt_max_partition_iterations]: Maximum iterations for TensorRT parser to get capability.\n"

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -247,7 +247,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     size_t num_of_threads = 8;             // [num_of_threads]: Overrides the accelerator default value of number of threads with this value at runtime.
     bool use_compiled_network = false;     // [use_compiled_network]: Can be enabled to directly import pre-compiled blobs if exists.
     std::string blob_dump_path = "";       // [blob_dump_path]: Explicitly specify the path where you would like to dump and load the blobs for the use_compiled_network(save/load blob) feature. This overrides the default path.
-    bool enable_gpu_throttling = false;    // [enable_gpu_throttling]: Enables GPU Throttling (Reduces CPU Utilization when using GPU)
+    bool enable_opencl_throttling = false;    // [enable_opencl_throttling]: Enables OpenCL queue throttling for GPU device (Reduces CPU Utilization when using GPU)
 #ifdef _MSC_VER
     std::string ov_string = ToMBString(performance_test_config.run_config.ep_runtime_config_string);
 #else
@@ -298,13 +298,13 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
         } else {
           ORT_THROW("[ERROR] [OpenVINO] The value for the key 'use_compiled_network' should be a boolean i.e. true or false. Default value is false.\n");
         }
-      } else if (key == "enable_gpu_throttling") {
+      } else if (key == "enable_opencl_throttling") {
         if (value == "true" || value == "True") {
-          enable_gpu_throttling = true;
+          enable_opencl_throttling = true;
         } else if (value == "false" || value == "False") {
-          enable_gpu_throttling = false;
+          enable_opencl_throttling = false;
         } else {
-          ORT_THROW("[ERROR] [OpenVINO] The value for the key 'enable_gpu_throttling' should be a boolean i.e. true or false. Default value is false.\n");
+          ORT_THROW("[ERROR] [OpenVINO] The value for the key 'enable_opencl_throttling' should be a boolean i.e. true or false. Default value is false.\n");
         }
       } else if (key == "num_of_threads") {
         std::stringstream sstream(value);
@@ -325,7 +325,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     options.num_of_threads = num_of_threads;                    // To set number of free InferRequests, default is 8
     options.use_compiled_network = use_compiled_network;        // To use_compiled_network, default is false
     options.blob_dump_path = blob_dump_path.c_str();            // sets the blob_dump_path, default is ""
-    options.enable_gpu_throttling = enable_gpu_throttling;      // Enables GPU Throttling (Reduces CPU Utilization)
+    options.enable_opencl_throttling = enable_opencl_throttling;      // Enables GPU Throttling (Reduces CPU Utilization)
     session_options.AppendExecutionProvider_OpenVINO(options);
 #else
     ORT_THROW("OpenVINO is not supported in this build\n");

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -247,7 +247,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     size_t num_of_threads = 8;             // [num_of_threads]: Overrides the accelerator default value of number of threads with this value at runtime.
     bool use_compiled_network = false;     // [use_compiled_network]: Can be enabled to directly import pre-compiled blobs if exists.
     std::string blob_dump_path = "";       // [blob_dump_path]: Explicitly specify the path where you would like to dump and load the blobs for the use_compiled_network(save/load blob) feature. This overrides the default path.
-
+    bool enable_gpu_throttling = false;    // [enable_gpu_throttling]: Enables GPU Throttling (Reduces CPU Utilization when using GPU)
 #ifdef _MSC_VER
     std::string ov_string = ToMBString(performance_test_config.run_config.ep_runtime_config_string);
 #else
@@ -298,6 +298,14 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
         } else {
           ORT_THROW("[ERROR] [OpenVINO] The value for the key 'use_compiled_network' should be a boolean i.e. true or false. Default value is false.\n");
         }
+      } else if (key == "enable_gpu_throttling") {
+        if (value == "true" || value == "True") {
+          enable_gpu_throttling = true;
+        } else if (value == "false" || value == "False") {
+          enable_gpu_throttling = false;
+        } else {
+          ORT_THROW("[ERROR] [OpenVINO] The value for the key 'enable_gpu_throttling' should be a boolean i.e. true or false. Default value is false.\n");
+        }
       } else if (key == "num_of_threads") {
         std::stringstream sstream(value);
         sstream >> num_of_threads;
@@ -317,6 +325,7 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
     options.num_of_threads = num_of_threads;                    // To set number of free InferRequests, default is 8
     options.use_compiled_network = use_compiled_network;        // To use_compiled_network, default is false
     options.blob_dump_path = blob_dump_path.c_str();            // sets the blob_dump_path, default is ""
+    options.enable_gpu_throttling = enable_gpu_throttling;      // Enables GPU Throttling (Reduces CPU Utilization)
     session_options.AppendExecutionProvider_OpenVINO(options);
 #else
     ORT_THROW("OpenVINO is not supported in this build\n");


### PR DESCRIPTION
**Description**: 
Enable GPU Throttling as a runtime option.

**Motivation and Context**
-  Implement GPU Throttling feature. Added GPU Throttling feature for iGPU's.
    when user enables it as a runtime option, it helps in reducing overall CPU usage of the application
-  Added changes to exercise this option using onnxruntime_perf_test application.

**Note:**
The changes have been verified by both c++ API and Python API.

**For C++ API:** Used onnxruntime_perf_test to verify it.
**Command:**
./onnxruntime_perf_test -r 100 -c 1 -v -e openvino -i "device_type|GPU_FP16 enable_gpu_throttling|true" /home/intel/maajid/project_files/data_models_onnx_and_tests/resnet50v1/resnet50-v1-7.onnx

**For Python API:** 
sess = rt.InferenceSession(str(sys.argv[1]), providers=['OpenVINOExecutionProvider'], provider_options=[{'device_type' : sys.argv[4]}, {'enable_gpu_throttling' : 'true'}])

**Some Testing results with Resnet50 Model (verified and working):**
Refer the comments section here:
https://jira.devtools.intel.com/browse/HAFP-1803