### PR TITLE
Fix 2021.3 branch

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -34,7 +34,9 @@ class BasicBackend : public IBackend {
   bool ValidateSubgraph(std::map<std::string, std::shared_ptr<ngraph::Node>>& const_outputs_map);
   void PopulateConfigValue(OVConfig& config);
   void EnableCaching();
+  #if defined(OPENVINO_2022_1)
   void EnableGPUThrottling(OVConfig& config);
+  #endif 
   void StartAsyncInference(Ort::CustomOpApi& ort, OrtKernelContext* context, std::shared_ptr<OVInferRequest> infer_request);
 
 #ifdef IO_BUFFER_ENABLED

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -11,7 +11,7 @@ using Exception = InferenceEngine::Exception;
 using WaitMode = InferenceEngine::InferRequest::WaitMode;
 #else
 using Exception = InferenceEngine::details::InferenceEngineException;
-using WaitMode = InferenceEngine::InferRequest::WaitMode;
+using WaitMode = InferenceEngine::IInferRequest::WaitMode;
 #endif
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <inference_engine.hpp>
-
 #if defined (OPENVINO_2022_1)
 #include <openvino/core/core.hpp>
 #include <openvino/runtime/runtime.hpp>
@@ -72,11 +71,6 @@ class OVExeNetwork;
     #else 
         OVExeNetwork(InferenceEngine::ExecutableNetwork md) { obj = md; }
         OVExeNetwork() { obj = InferenceEngine::ExecutableNetwork(); }
-        #if (defined OPENVINO_2021_2) || (defined OPENVINO_2021_3)
-        void export_network(std::ofstream& model_stream) {
-          obj.Export(model_stream);
-        }
-        #endif 
         InferenceEngine::ExecutableNetwork& Get() { return obj ; }
     #endif
         OVInferRequest CreateInferRequest();


### PR DESCRIPTION
Enable 2022.1 Branch to support OV EP Backward Compatibility to OV 2021.3 

**Motivation and Context**
- This change is required to ensure that OV 2021.3 is not broken 
- If it fixes an open issue, please link to the issue here.
