### PR TITLE
export param changes

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
+++ b/orttraining/orttraining/python/training/ortmodule/_graph_execution_manager.py
@@ -451,7 +451,7 @@ class GraphExecutionManager(GraphExecutionInterface):
                                              'verbose': self._debug_options.logging.log_level < LogLevel.WARNING,
                                              'operator_export_type': OperatorExportTypes.ONNX_ATEN_FALLBACK,
                                              'export_params': True,
-                                             'keep_initializers_as_inputs': True}
+                                             'keep_initializers_as_inputs': False}
 
                    invalid_args = self._export_extra_kwargs.keys() & required_export_kwargs.keys()
                    assert len(invalid_args) == 0,\


### PR DESCRIPTION
Description:

This PR sets the right values for export param 'keep_initializers_as_input'.

Motivation:

Bug fix. Existing option leads to incorrect values during export to onnx. 