### PR TITLE
Log compute time for FIL calculation

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1761,6 +1761,10 @@ if (onnxruntime_USE_OPENVINO)
     add_definitions(-DDEVICE_NAME="${onnxruntime_USE_OPENVINO_DEVICE}")
   endif()
 
+  if($ENV{FIL_ENABLED})
+    add_definitions(-DOPENVINO_FIL_ENABLED=1)
+  endif()
+  
 endif()
 
 if (onnxruntime_USE_VITISAI)

--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -261,6 +261,14 @@ BackendManager::ReWriteBatchDimWithOne(const ONNX_NAMESPACE::ModelProto& model_p
 }
 
 void BackendManager::Compute(Ort::CustomOpApi api, OrtKernelContext* context) {
+  std::chrono::high_resolution_clock::time_point start_compute, end_compute;
+  #ifdef OPENVINO_FIL_ENABLED
+    static bool fil_enabled = true;
+    if(fil_enabled) {
+      start_compute = std::chrono::high_resolution_clock::now();
+      LOGS_DEFAULT(INFO) << "Start Compute"; 
+    }
+  #endif
   bool use_dynamic_backend = true;
   if (GetGlobalContext().enable_dynamic_shapes && subgraph_context_.has_dynamic_input_shape &&
       GetGlobalContext().device_type.find("CPU") != std::string::npos) {
@@ -299,6 +307,15 @@ void BackendManager::Compute(Ort::CustomOpApi api, OrtKernelContext* context) {
   } else {
     concrete_backend_->Infer(api, context);
   }
+  #ifdef OPENVINO_FIL_ENABLED
+    if(fil_enabled) {
+      end_compute = std::chrono::high_resolution_clock::now();
+      LOGS_DEFAULT(INFO) << "End Compute";
+      std::chrono::duration<double> compute_time = end_compute - start_compute;
+      std::cout << "Compute Time: " << compute_time.count() << " s" << std::endl;
+      fil_enabled = false; //calculating compute time for first run only
+    }
+  #endif
 }
 
 void BackendManager::ShutdownBackendManager() {

--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -264,9 +264,9 @@ void BackendManager::Compute(Ort::CustomOpApi api, OrtKernelContext* context) {
   std::chrono::high_resolution_clock::time_point start_compute, end_compute;
   #ifdef OPENVINO_FIL_ENABLED
     static bool fil_enabled = true;
-    if(fil_enabled) {
+    if (fil_enabled) {
       start_compute = std::chrono::high_resolution_clock::now();
-      LOGS_DEFAULT(INFO) << "Start Compute"; 
+      LOGS_DEFAULT(INFO) << "Start Compute";
     }
   #endif
   bool use_dynamic_backend = true;
@@ -308,12 +308,12 @@ void BackendManager::Compute(Ort::CustomOpApi api, OrtKernelContext* context) {
     concrete_backend_->Infer(api, context);
   }
   #ifdef OPENVINO_FIL_ENABLED
-    if(fil_enabled) {
+    if (fil_enabled) {
       end_compute = std::chrono::high_resolution_clock::now();
       LOGS_DEFAULT(INFO) << "End Compute";
       std::chrono::duration<double> compute_time = end_compute - start_compute;
       std::cout << "Compute Time: " << compute_time.count() << " s" << std::endl;
-      fil_enabled = false; //calculating compute time for first run only
+      fil_enabled = false;  // calculating compute time for first run only
     }
   #endif
 }


### PR DESCRIPTION
**Description**: Adding condition to log compute time when FIL_ENABLED flag is 1

**Motivation and Context**
- To calculate the First inference latency when FIL_ENABLED flag is set to 1, compute time is to be logged.
- FIL is considered as session creation time + compute time.
