### PR TITLE
[OpenVINO] iterate over ONNX names when fetching output tensors

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -438,27 +438,19 @@ void BasicBackend::CompleteAsyncInference(Ort::CustomOpApi& ort, OrtKernelContex
   infer_request->WaitRequest();
   #if defined (OV_API_20)
   auto graph_output_info = exe_network_.Get().outputs();
-  for (auto output_info_iter = graph_output_info.begin();
-       output_info_iter != graph_output_info.end(); ++output_info_iter) {
-    OVTensorPtr graph_output_blob;
-    auto output_names = output_info_iter->get_names();
-    std::string onnx_output_name;
-    std::string output_name;
-    bool output_name_found = false;
+  for (const auto& it : subgraph_context_.output_names) {
+    const auto& output_name = it.first;
     // using the output name retrieved from ONNX original to match with the output names returned by OV tensors
-    for (auto it = subgraph_context_.output_names.begin(); it != subgraph_context_.output_names.end(); ++it) {
-      onnx_output_name = it->first;
-      if (output_names.find(onnx_output_name) != output_names.end()) {
-        //Assigning the output_name
-        output_name = it->first;
-        output_name_found = true;
-        break;
-      }
+    bool output_name_found = std::any_of(graph_output_info.begin(), graph_output_info.end(),
+                                         [&output_name] (const ov::Output<const ov::Node>& node) {
+                                           const auto& names = node.get_names();
+                                           return names.find(output_name) != names.end();
+                                         });
+    if (!output_name_found) {
+      ORT_THROW(log_tag + "Output names mismatch between OpenVINO and ONNX. [ONNX Output: ] " + output_name + " doesn't exist in the list of OpenVINO output tensor names");
     }
-    if(!output_name_found) {
-      ORT_THROW(log_tag + "Output names mismatch between OpenVINO and ONNX. [ONNX Output: ] " + onnx_output_name + " doesn't exist in the list of OpenVINO output tensor names");
-    }
-    graph_output_blob = infer_request->GetTensor(output_name);
+
+    OVTensorPtr graph_output_blob = infer_request->GetTensor(output_name);
     size_t batch_size = 1;
     auto output_tensor = GetOutputTensor(ort, context, batch_size, infer_request, output_name, subgraph_context_.output_names);
     auto mem_info = ort.GetTensorMemoryInfo(output_tensor);

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -128,7 +128,7 @@ namespace onnxruntime {
         }
     }
    
-    OVTensorPtr OVInferRequest::GetTensor(std::string& input_name) {
+    OVTensorPtr OVInferRequest::GetTensor(const std::string& input_name) {
         try {
           #if defined (OV_API_20)
           auto tobj = ovInfReq.get_tensor(input_name);
@@ -145,7 +145,7 @@ namespace onnxruntime {
         }
     }
 
-    void OVInferRequest::SetTensor(std::string& name, OVTensorPtr& blob) {
+    void OVInferRequest::SetTensor(const std::string& name, OVTensorPtr& blob) {
         try {
           #if defined(OV_API_20)
           ovInfReq.set_tensor(name, *(blob.get()));

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -102,8 +102,8 @@ class OVExeNetwork;
         InferenceEngine::InferRequest infReq;
     #endif
     public:
-        OVTensorPtr GetTensor(std::string& name);
-        void SetTensor(std::string& name, OVTensorPtr& blob);
+        OVTensorPtr GetTensor(const std::string& name);
+        void SetTensor(const std::string& name, OVTensorPtr& blob);
         void StartAsync();
         void WaitRequest();
         void QueryStatus();


### PR DESCRIPTION
The change fixes case when subgraph cut ends with a node that has
output that is connected to Identity, e.g.
```
        +-----------+
        | Node      |
        | output: A |
        +-----------+
          |       |
          |       |
          v       ----
                     |
                     v
               +-----------+
               | Identity  |
               | output: B |
               +-----------+
                     |
                     v
```
This ONNX subgraph has two outputs: A and B. When it's read by
OpenVINO, Identity node is eliminated and its output name is appended
to Node's output names (so {"A", "B"}). So the final OpenVINO model
has two outputs that point to the same tensor with names set {"A", "B"}.
When CompleteAsyncInference function iterates over OpenVINO outputs
and tries to match it with ONNX name - it matches with the first name only.
Iterating over ONNX names first ensures that no output from the original
subgraph is missed.
