### PR TITLE
[OpenVINO] iterate over ONNX names when fetching output tensors

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -128,7 +128,7 @@ namespace onnxruntime {
         }
     }
    
-    OVTensorPtr OVInferRequest::GetTensor(std::string& input_name) {
+    OVTensorPtr OVInferRequest::GetTensor(const std::string& input_name) {
         try {
           #if defined (OV_API_20)
           auto tobj = ovInfReq.get_tensor(input_name);
@@ -145,7 +145,7 @@ namespace onnxruntime {
         }
     }
 
-    void OVInferRequest::SetTensor(std::string& name, OVTensorPtr& blob) {
+    void OVInferRequest::SetTensor(const std::string& name, OVTensorPtr& blob) {
         try {
           #if defined(OV_API_20)
           ovInfReq.set_tensor(name, *(blob.get()));

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -20,6 +20,8 @@
 #endif
 #endif
 
+#include <string>
+
 namespace onnxruntime {
 namespace openvino_ep {
 class OVCore;
@@ -104,8 +106,8 @@ class OVExeNetwork;
         InferenceEngine::InferRequest infReq;
     #endif
     public:
-        OVTensorPtr GetTensor(std::string& name);
-        void SetTensor(std::string& name, OVTensorPtr& blob);
+        OVTensorPtr GetTensor(const std::string& name);
+        void SetTensor(const std::string& name, OVTensorPtr& blob);
         void StartAsync();
         void WaitRequest();
         void QueryStatus();


### PR DESCRIPTION
The change fixes case when subgraph cut ends with a node that has output that is connected to Identity, e.g.
```
        +-----------+
        | Node      |
        | output: A |
        +-----------+
          |       |
          |       |
          v       ----
                     |
                     v
               +-----------+
               | Identity  |
               | output: B |
               +-----------+
                     |
                     v
```
This ONNX subgraph has two outputs: A and B. When it's read by OpenVINO, Identity node is eliminated and its output name is appended to Node's output names (so {"A", "B"}). So the final OpenVINO model has two outputs that point to the same tensor with names set {"A", "B"}. When CompleteAsyncInference function iterates over OpenVINO outputs and tries to match it with ONNX name - it matches with the first name only. Iterating over ONNX names first ensures that no output from the original subgraph is missed.
