### PR TITLE
Nuget update for OVEP 4.3

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -709,14 +709,16 @@ def generate_files(list, args):
                 + '\\native" />'
             )
             # usb-ma2x8x.mvcmd
-            files_list.append(
-                "<file src="
-                + '"'
-                + os.path.join(dll_list_path, "usb-ma2x8x.mvcmd")
-                + runtimes_target
-                + args.target_architecture
-                + '\\native" />'
-            )
+            # OpenVINO 2022.3 doesn't have usb-ma2x8x.mvcmd
+            if "2022.3" not in openvino_path:
+                files_list.append(
+                    "<file src="
+                    + '"'
+                    + os.path.join(dll_list_path, "usb-ma2x8x.mvcmd")
+                    + runtimes_target
+                    + args.target_architecture
+                    + '\\native" />'
+                )
             for tbb_element in os.listdir(tbb_list_path):
                 if tbb_element.endswith("dll"):
                     files_list.append(


### PR DESCRIPTION
Removed usb-ma2x8x.mvcmd from dll list for 2022.3 as the release doesn't have this file.