### PR TITLE
Allow dynamic shapes inference in GPU

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -32,8 +32,8 @@ void BackendManager::ReleaseGlobalContext() {
 }
 
 BackendManager::BackendManager(const onnxruntime::Node& fused_node,
-    const onnxruntime::GraphViewer& subgraph,
-    const logging::Logger& logger) {
+                               const onnxruntime::GraphViewer& subgraph,
+                               const logging::Logger& logger) {
   auto prec_str = GetGlobalContext().precision_str;
   if (prec_str == "FP32") {
     subgraph_context_.precision = InferenceEngine::Precision::FP32;
@@ -75,37 +75,33 @@ BackendManager::BackendManager(const onnxruntime::Node& fused_node,
 
   if (ModelHasSymbolicInputDims(subgraph)) {
     subgraph_context_.has_dynamic_input_shape = true;
-    if (GetGlobalContext().device_type.find("CPU") != std::string::npos) {
-      LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has symbolic input dims and "
-                       << "device_type is CPU.";
+    LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has symbolic input dims";
+    if (GetGlobalContext().device_type.find("CPU") != std::string::npos ||
+        GetGlobalContext().device_type.find("GPU") != std::string::npos) {
       if (GetGlobalContext().enable_dynamic_shapes) {
         LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Starting backend initialization. "
-                        << "Creating backend Dynamic Shapes";
-          try {
-            concrete_backend_ = BackendFactory::MakeBackend(*model_proto_,
-                                                            GetGlobalContext(),
-                                                            subgraph_context_);
-          } catch (std::string const & msg) {
-              throw msg;
-          }
+                           << "Creating backend Dynamic Shapes";
+        try {
+          concrete_backend_ = BackendFactory::MakeBackend(*model_proto_,
+                                                          GetGlobalContext(),
+                                                          subgraph_context_);
+        } catch (std::string const& msg) {
+          throw msg;
+        }
         LOGS_DEFAULT(INFO) << "[OpenVINO-EP] "
-                        << "Backend created for graph " << subgraph_context_.subgraph_name;
+                           << "Backend created for graph " << subgraph_context_.subgraph_name;
       }
     }
-  } else if (ModelHasSymbolicInputDims(subgraph) &&
-      GetGlobalContext().device_type.find("GPU") != std::string::npos) {
-    LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has symbolic input dims. Defering backend initialization";
-    subgraph_context_.has_dynamic_input_shape = true;
   } else {
-    LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has concreate input dims. Initializing backend for graph " << subgraph_context_.subgraph_name;
+    LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has concrerte input dims. Initializing backend for graph " << subgraph_context_.subgraph_name;
 
     subgraph_context_.has_dynamic_input_shape = false;
     try {
       concrete_backend_ = BackendFactory::MakeBackend(*model_proto_,
                                                       GetGlobalContext(),
                                                       subgraph_context_);
-    } catch (std::string const & msg) {
-        throw msg;
+    } catch (std::string const& msg) {
+      throw msg;
     }
   }
 }
@@ -186,7 +182,6 @@ BackendManager::GetModelProtoFromFusedNode(const onnxruntime::Node& fused_node,
 }
 
 std::vector<std::vector<int64_t>> GetInputTensorShapes(Ort::KernelContext& context) {
-
   const auto input_count = context.GetInputCount();
   std::vector<std::vector<int64_t>> input_shapes;
   input_shapes.reserve(input_count);
@@ -202,7 +197,7 @@ std::string MakeMapKeyString(const std::vector<std::vector<int64_t>>& shapes,
                              const std::string& device_type) {
   std::string key;
   key += device_type;
-  key += "|";  //separator
+  key += "|";  // separator
   for (auto shape : shapes) {
     for (auto dim : shape) {
       std::ostringstream o;
@@ -254,20 +249,20 @@ BackendManager::ReWriteBatchDimWithOne(const ONNX_NAMESPACE::ModelProto& model_p
 void BackendManager::Compute(OrtKernelContext* context) {
   Ort::KernelContext ctx(context);
   std::chrono::high_resolution_clock::time_point start_compute, end_compute;
-  #ifdef OPENVINO_FIL_ENABLED
-    static bool fil_enabled = true;
-    if (fil_enabled) {
-      start_compute = std::chrono::high_resolution_clock::now();
-      LOGS_DEFAULT(INFO) << "Start Compute";
-    }
-  #endif
+#ifdef OPENVINO_FIL_ENABLED
+  static bool fil_enabled = true;
+  if (fil_enabled) {
+    start_compute = std::chrono::high_resolution_clock::now();
+    LOGS_DEFAULT(INFO) << "Start Compute";
+  }
+#endif
   bool use_dynamic_backend = true;
   if (GetGlobalContext().enable_dynamic_shapes && subgraph_context_.has_dynamic_input_shape &&
-      GetGlobalContext().device_type.find("CPU") != std::string::npos) {
+      (GetGlobalContext().device_type.find("CPU") != std::string::npos ||
+       GetGlobalContext().device_type.find("GPU") != std::string::npos)) {
     concrete_backend_->Infer(context);
     use_dynamic_backend = false;
-  }
-  else if (use_dynamic_backend && subgraph_context_.has_dynamic_input_shape) {
+  } else if (use_dynamic_backend && subgraph_context_.has_dynamic_input_shape) {
     std::vector<std::vector<int64_t>> tensor_shapes = GetInputTensorShapes(ctx);
     auto key = MakeMapKeyString(tensor_shapes, GetGlobalContext().device_type);
 
@@ -275,16 +270,16 @@ void BackendManager::Compute(OrtKernelContext* context) {
     auto search = backend_map_.find(key);
     if (search == backend_map_.end()) {
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP] "
-                        << "Creating concrete backend for key: " << key;
+                         << "Creating concrete backend for key: " << key;
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP] "
-                        << "Backend created for graph " << subgraph_context_.subgraph_name;
+                         << "Backend created for graph " << subgraph_context_.subgraph_name;
       auto modelproto_with_concrete_shapes = ReWriteInputShapeInfo(*model_proto_, tensor_shapes);
       try {
         dynamic_backend = BackendFactory::MakeBackend(*modelproto_with_concrete_shapes,
-                                                        GetGlobalContext(),
-                                                        subgraph_context_);
-      } catch (std::string const & msg) {
-          throw msg;
+                                                      GetGlobalContext(),
+                                                      subgraph_context_);
+      } catch (std::string const& msg) {
+        throw msg;
       }
       backend_map_.insert({key, dynamic_backend});
     } else {
@@ -295,15 +290,15 @@ void BackendManager::Compute(OrtKernelContext* context) {
   } else {
     concrete_backend_->Infer(context);
   }
-  #ifdef OPENVINO_FIL_ENABLED
-    if (fil_enabled) {
-      end_compute = std::chrono::high_resolution_clock::now();
-      LOGS_DEFAULT(INFO) << "End Compute";
-      std::chrono::duration<double> compute_time = end_compute - start_compute;
-      std::cout << "Compute Time: " << compute_time.count() << " s" << std::endl;
-      fil_enabled = false;  // calculating compute time for first run only
-    }
-  #endif
+#ifdef OPENVINO_FIL_ENABLED
+  if (fil_enabled) {
+    end_compute = std::chrono::high_resolution_clock::now();
+    LOGS_DEFAULT(INFO) << "End Compute";
+    std::chrono::duration<double> compute_time = end_compute - start_compute;
+    std::cout << "Compute Time: " << compute_time.count() << " s" << std::endl;
+    fil_enabled = false;  // calculating compute time for first run only
+  }
+#endif
 }
 
 void BackendManager::ShutdownBackendManager() {

--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -93,7 +93,7 @@ BackendManager::BackendManager(const onnxruntime::Node& fused_node,
       }
     }
   } else {
-    LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has concrerte input dims. Initializing backend for graph " << subgraph_context_.subgraph_name;
+    LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has concrete input dims. Initializing backend for graph " << subgraph_context_.subgraph_name;
 
     subgraph_context_.has_dynamic_input_shape = false;
     try {

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -24,18 +24,18 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                            const SubGraphContext& subgraph_context)
     : global_context_(global_context), subgraph_context_(subgraph_context) {
   std::string& hw_target = (global_context_.device_id != "") ? global_context_.device_id : global_context_.device_type;
-  try{
-    #ifndef NDEBUG
-      if (IsDebugEnabled()) {
-        std::string file_name = subgraph_context.subgraph_name + "_static.onnx";
-        std::fstream outfile(file_name, std::ios::out | std::ios::trunc | std::ios::binary);
-        model_proto.SerializeToOstream(outfile);
-        // DumpOnnxModelProto(model_proto, subgraph_context.subgraph_name + "_static.onnx");
-      }
-    #endif
+  try {
+#ifndef NDEBUG
+    if (IsDebugEnabled()) {
+      std::string file_name = subgraph_context.subgraph_name + "_static.onnx";
+      std::fstream outfile(file_name, std::ios::out | std::ios::trunc | std::ios::binary);
+      model_proto.SerializeToOstream(outfile);
+      // DumpOnnxModelProto(model_proto, subgraph_context.subgraph_name + "_static.onnx");
+    }
+#endif
     ie_cnn_network_ = CreateOVModel(model_proto, global_context_, subgraph_context_, const_outputs_map_);
-  } catch (std::string const & msg) {
-      throw msg;
+  } catch (std::string const& msg) {
+    throw msg;
   }
   if (ValidateSubgraph(const_outputs_map_))
     return;
@@ -44,43 +44,42 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
   ov::AnyMap device_config;
   PopulateConfigValue(device_config);
 
-  //Enable caching
+  // Enable caching
   EnableCaching();
 
-  //Setting OpenCL queue throttling for GPU
+  // Setting OpenCL queue throttling for GPU
   EnableGPUThrottling(device_config);
 
-  #if defined(IO_BUFFER_ENABLED)
-    try {
-      if ((global_context.device_type.find("GPU") != std::string::npos)  &&
+#if defined(IO_BUFFER_ENABLED)
+  try {
+    if ((global_context.device_type.find("GPU") != std::string::npos) &&
         (global_context_.context != nullptr) &&
         (openvino_ep::BackendManager::GetGlobalContext().is_wholly_supported_graph)) {
-        LOGS_DEFAULT(INFO) << log_tag << "IO Buffering Enabled";
-        cl_context ctx = static_cast<cl_context>(global_context_.context);
-        #ifdef OV_API_20
-          remote_context_ = new ov::intel_gpu::ocl::ClContext(global_context_.ie_core.Get(), ctx);
-        #else
-          remote_context_ = InferenceEngine::gpu::make_shared_context(global_context_.ie_core.Get(), hw_target, ctx);
-        #endif
-        exe_network_ = global_context_.ie_core.LoadNetwork(ie_cnn_network_, remote_context_, subgraph_context_.subgraph_name);
-      } else {
-          exe_network_ = global_context_.ie_core.LoadNetwork(ie_cnn_network_, hw_target, device_config, subgraph_context_.subgraph_name);
-      }
-    }catch (const char* msg) {
-        throw(msg);
-    }
-  #else
-  try{
+      LOGS_DEFAULT(INFO) << log_tag << "IO Buffering Enabled";
+      cl_context ctx = static_cast<cl_context>(global_context_.context);
+#ifdef OV_API_20
+      remote_context_ = new ov::intel_gpu::ocl::ClContext(global_context_.ie_core.Get(), ctx);
+#else
+      remote_context_ = InferenceEngine::gpu::make_shared_context(global_context_.ie_core.Get(), hw_target, ctx);
+#endif
+      exe_network_ = global_context_.ie_core.LoadNetwork(ie_cnn_network_, remote_context_, subgraph_context_.subgraph_name);
+    } else {
       exe_network_ = global_context_.ie_core.LoadNetwork(ie_cnn_network_, hw_target, device_config, subgraph_context_.subgraph_name);
+    }
   } catch (const char* msg) {
-      throw(msg);
+    throw(msg);
   }
-  #endif
+#else
+  try {
+    exe_network_ = global_context_.ie_core.LoadNetwork(ie_cnn_network_, hw_target, device_config, subgraph_context_.subgraph_name);
+  } catch (const char* msg) {
+    throw(msg);
+  }
+#endif
   LOGS_DEFAULT(INFO) << log_tag << "Loaded model to the plugin";
 
-
-  //The infer_requests_ pool will be intialized with a default value of 8 infer_request's
-  //The nireq value can also be configured to any num_of_threads during runtime
+  // The infer_requests_ pool will be intialized with a default value of 8 infer_request's
+  // The nireq value can also be configured to any num_of_threads during runtime
   size_t nireq = global_context_.num_of_threads;
   LOGS_DEFAULT(INFO) << log_tag << "The value of nireq being used is: " << nireq;
 #ifndef NDEBUG
@@ -107,22 +106,22 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
   //   device_config.emplace(ov::hint::inference_precision(global_context_.precision_str));
   // }
   device_config = {};
-  #ifndef NDEBUG
-    if (openvino_ep::backend_utils::IsDebugEnabled()) {
-      device_config.emplace(ov::enable_profiling(true));
-    }
-  #endif
+#ifndef NDEBUG
+  if (openvino_ep::backend_utils::IsDebugEnabled()) {
+    device_config.emplace(ov::enable_profiling(true));
+  }
+#endif
 }
 
 void BasicBackend::EnableCaching() {
   if (!global_context_.cache_dir.empty() && global_context_.is_wholly_supported_graph) {
-    #if defined (OPENVINO_2022_3) || (OPENVINO_2023_0)
-      #if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__BORLANDC__)
-      _putenv_s("OV_GPU_CACHE_MODEL", "1");
-      #else
-      setenv("OV_GPU_CACHE_MODEL", "1", 1);
-      #endif
-    #endif
+#if defined(OPENVINO_2022_3) || (OPENVINO_2023_0)
+#if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__BORLANDC__)
+    _putenv_s("OV_GPU_CACHE_MODEL", "1");
+#else
+    setenv("OV_GPU_CACHE_MODEL", "1", 1);
+#endif
+#endif
     LOGS_DEFAULT(INFO) << log_tag << "Enables Caching";
     global_context_.ie_core.SetCache(global_context_.cache_dir);
   }
@@ -138,11 +137,11 @@ void BasicBackend::EnableGPUThrottling(ov::AnyMap& device_config) {
 // Starts an asynchronous inference request for data in slice indexed by batch_slice_idx on
 // an Infer Request indexed by infer_req_idx
 void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferRequestPtr infer_request) {
-  try{
+  try {
     auto graph_input_info = exe_network_.Get().inputs();
     int input_idx = 0;
     for (auto input_info_iter = graph_input_info.begin();
-      input_info_iter != graph_input_info.end(); ++input_info_iter) {
+         input_info_iter != graph_input_info.end(); ++input_info_iter) {
       auto input_names = input_info_iter->get_names();
       std::string onnx_input_name;
       std::string input_name;
@@ -155,14 +154,15 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
       }
       // using the input name retrieved from ONNX original to match with the input names returned by OV tensors
       if (input_names.find(onnx_input_name) != input_names.end()) {
-          input_name = onnx_input_name;
+        input_name = onnx_input_name;
       } else {
         throw(log_tag + "Input names mismatch between OpenVINO and ONNX. " + onnx_input_name + " doesn't exist in the list of OpenVINO input tensor names");
       }
       size_t batch_slice_idx = 0;
       if (subgraph_context_.has_dynamic_input_shape &&
-        global_context_.enable_dynamic_shapes == true &&
-        global_context_.device_type.find("CPU") != std::string::npos) {
+          global_context_.enable_dynamic_shapes == true &&
+          (global_context_.device_type.find("CPU") != std::string::npos ||
+           global_context_.device_type.find("GPU") != std::string::npos)) {
         auto tensor = context.GetInput(subgraph_context_.input_names.at(input_name));
         auto tensor_info = tensor.GetTensorTypeAndShapeInfo();
         auto tensor_shape = tensor_info.GetShape();
@@ -171,42 +171,42 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
         ov::Shape input_tensor_shape = ov::Shape(tensor_size, 0);
         for (auto i = tensor_shape.begin(); i != tensor_shape.end(); ++i) {
           input_tensor_shape[tensor_iter] = *i;
-          tensor_iter+=1;
+          tensor_iter += 1;
         }
         auto input = ie_cnn_network_->get_parameters().at(input_idx);
         OVTensorPtr tensor_ptr = std::make_shared<ov::Tensor>(input->get_element_type(), input_tensor_shape);
         FillInputBlob(tensor_ptr, batch_slice_idx, input_name, context, subgraph_context_);
-        try{
+        try {
           infer_request->SetTensor(input_name, tensor_ptr);
         } catch (const char* msg) {
-            throw(msg);
+          throw(msg);
         }
       } else {
         OVTensorPtr graph_input_blob;
-          try{
-            graph_input_blob = infer_request->GetTensor(input_name);
-          } catch (const char* msg) {
-              throw(msg);
-          }
+        try {
+          graph_input_blob = infer_request->GetTensor(input_name);
+        } catch (const char* msg) {
+          throw(msg);
+        }
         FillInputBlob(graph_input_blob, batch_slice_idx, input_name, context, subgraph_context_);
       }
       input_idx++;
     }
     // Start Async inference
     infer_request->StartAsync();
-    }catch (const char* msg) {
-      throw(msg);
-    }
+  } catch (const char* msg) {
+    throw(msg);
+  }
 }
 
 #ifdef IO_BUFFER_ENABLED
-//Wait for Remote Aynchronous inference completion
+// Wait for Remote Aynchronous inference completion
 void BasicBackend::StartRemoteAsyncInference(Ort::KernelContext& context, OVInferRequestPtr infer_request) {
-  try{
+  try {
     auto graph_input_info = exe_network_.Get().inputs();
     int input_idx = 0;
     for (auto input_info_iter = graph_input_info.begin();
-      input_info_iter != graph_input_info.end(); ++input_info_iter) {
+         input_info_iter != graph_input_info.end(); ++input_info_iter) {
       auto input_names = input_info_iter->get_names();
       std::string onnx_input_name;
       std::string input_name;
@@ -219,7 +219,7 @@ void BasicBackend::StartRemoteAsyncInference(Ort::KernelContext& context, OVInfe
       }
       // using the input name retrieved from ONNX original to match with the input names returned by OV tensors
       if (input_names.find(onnx_input_name) != input_names.end()) {
-          input_name = onnx_input_name;
+        input_name = onnx_input_name;
       } else {
         throw(log_tag + "Input names mismatch between OpenVINO and ONNX. " + onnx_input_name + " doesn't exist in the list of OpenVINO input tensor names");
       }
@@ -229,10 +229,10 @@ void BasicBackend::StartRemoteAsyncInference(Ort::KernelContext& context, OVInfe
       // If the ORTValue wraps a device pointer
       auto mem_info = tensor.GetTensorMemoryInfo();
       if (mem_info.GetAllocatorName() == OpenVINO_GPU) {
-        //Get the shared buffer pointer
-        const void *tensor_data = tensor.GetTensorRawData();
+        // Get the shared buffer pointer
+        const void* tensor_data = tensor.GetTensorRawData();
         const cl::Buffer* shared_buffer_const = static_cast<const cl::Buffer*>(tensor_data);
-        //Create an Input Remote Blob
+        // Create an Input Remote Blob
         auto input = ie_cnn_network_->get_parameters().at(0);
         auto remote_blob = remote_context_->create_tensor(input->get_element_type(), input->get_shape(), *shared_buffer_const);
         ov::Tensor tensor = static_cast<ov::Tensor>(remote_blob);
@@ -246,10 +246,10 @@ void BasicBackend::StartRemoteAsyncInference(Ort::KernelContext& context, OVInfe
       }
     }
 
-    //Set the output blob as remote blob
+    // Set the output blob as remote blob
     auto graph_output_info = exe_network_.Get().outputs();
     for (auto output_info_iter = graph_output_info.begin();
-        output_info_iter != graph_output_info.end(); ++output_info_iter) {
+         output_info_iter != graph_output_info.end(); ++output_info_iter) {
       auto output_names = output_info_iter->get_names();
       std::string onnx_output_name;
       std::string output_name;
@@ -258,13 +258,13 @@ void BasicBackend::StartRemoteAsyncInference(Ort::KernelContext& context, OVInfe
       for (auto it = subgraph_context_.output_names.begin(); it != subgraph_context_.output_names.end(); ++it) {
         onnx_output_name = it->first;
         if (output_names.find(onnx_output_name) != output_names.end()) {
-          //Assigning the output_name
+          // Assigning the output_name
           output_name = it->first;
           output_name_found = true;
           break;
         }
       }
-      if(!output_name_found) {
+      if (!output_name_found) {
         throw std::string(log_tag + "Output names mismatch between OpenVINO and ONNX. [ONNX Output: ] " + onnx_output_name + " doesn't exist in the list of OpenVINO output tensor names");
       }
 
@@ -273,7 +273,7 @@ void BasicBackend::StartRemoteAsyncInference(Ort::KernelContext& context, OVInfe
       auto mem_info = tensor.GetTensorMemoryInfo();
       // Check if ORT Value wraps a device pointer
       if (mem_info.GetAllocatorName() == OpenVINO_GPU) {
-        const void *tensor_data = tensor.GetTensorRawData();
+        const void* tensor_data = tensor.GetTensorRawData();
         const cl::Buffer* shared_buffer_const = static_cast<const cl::Buffer*>(tensor_data);
         // Create a shared Blob, set the Infer Request Output Blob
         auto output = ie_cnn_network_->get_results().at(0);
@@ -290,8 +290,8 @@ void BasicBackend::StartRemoteAsyncInference(Ort::KernelContext& context, OVInfe
 
     // Start Async inference
     infer_request->StartAsync();
-  }catch (const char* msg) {
-      throw(msg);
+  } catch (const char* msg) {
+    throw(msg);
   }
 }
 #endif
@@ -300,11 +300,11 @@ void BasicBackend::StartRemoteAsyncInference(Ort::KernelContext& context, OVInfe
 // and copy the results into a slice location within the batched output buffer indexed by batch_slice_idx
 void BasicBackend::CompleteAsyncInference(Ort::KernelContext& context, OVInferRequestPtr infer_request) {
   // Wait for Async inference completion
-  try{
+  try {
     infer_request->WaitRequest();
     auto graph_output_info = exe_network_.Get().outputs();
     for (auto output_info_iter = graph_output_info.begin();
-        output_info_iter != graph_output_info.end(); ++output_info_iter) {
+         output_info_iter != graph_output_info.end(); ++output_info_iter) {
       OVTensorPtr graph_output_blob;
       auto output_names = output_info_iter->get_names();
       std::string onnx_output_name;
@@ -321,14 +321,17 @@ void BasicBackend::CompleteAsyncInference(Ort::KernelContext& context, OVInferRe
         }
       }
       if (!output_name_found) {
-        throw(log_tag + "Output names mismatch between OpenVINO and ONNX. "
-                  "[ONNX Output: ] " + onnx_output_name + " doesn't exist in the "
-                  "list of OpenVINO output tensor names");
+        throw(log_tag +
+              "Output names mismatch between OpenVINO and ONNX. "
+              "[ONNX Output: ] " +
+              onnx_output_name +
+              " doesn't exist in the "
+              "list of OpenVINO output tensor names");
       }
-      try{
+      try {
         graph_output_blob = infer_request->GetTensor(output_name);
       } catch (const char* msg) {
-          throw(msg);
+        throw(msg);
       }
       size_t batch_size = 1;
       auto output_tensor = GetOutputTensor(context, batch_size, infer_request, output_name, subgraph_context_.output_names);
@@ -354,8 +357,8 @@ void BasicBackend::CompleteAsyncInference(Ort::KernelContext& context, OVInferRe
         }
       }
     }
-  }catch (const char* msg) {
-      throw(msg);
+  } catch (const char* msg) {
+    throw(msg);
   }
 }
 
@@ -374,68 +377,68 @@ void BasicBackend::Infer(OrtKernelContext* ctx) {
       try {
         auto output_tensor = GetOutputTensor(context, out_name, subgraph_context_.output_names, node);
         FillOutputsWithConstantData(node, output_tensor);
-      } catch (std::string const & msg) {
+      } catch (std::string const& msg) {
         throw msg;
       }
     }
     // Get Output tensors
     LOGS_DEFAULT(INFO) << log_tag << "Inference successful";
-    //Enable CI Logs
-    if(IsCILogEnabled()) {
+    // Enable CI Logs
+    if (IsCILogEnabled()) {
       std::cout << "Inference successful" << std::endl;
     }
 
   } else {
-      //Requesting for an idle infer_request from a pool of infer_requests_
-      OVInferRequestPtr infer_request;
-      infer_request = inferRequestsQueue_->getIdleRequest();
+    // Requesting for an idle infer_request from a pool of infer_requests_
+    OVInferRequestPtr infer_request;
+    infer_request = inferRequestsQueue_->getIdleRequest();
 
-      #ifdef IO_BUFFER_ENABLED
-      if ((global_context_.device_type.find("GPU") != std::string::npos)  &&
-          (global_context_.context != nullptr) &&
-          (openvino_ep::BackendManager::GetGlobalContext().is_wholly_supported_graph)) {
-        try {
-          StartRemoteAsyncInference(context, infer_request);
-        } catch (std::string const & msg) {
-          throw msg;
-        }
-      } else {
-        try{
-          StartAsyncInference(context, infer_request);
-        } catch(std::string const & msg) {
-          throw msg;
-        }
+#ifdef IO_BUFFER_ENABLED
+    if ((global_context_.device_type.find("GPU") != std::string::npos) &&
+        (global_context_.context != nullptr) &&
+        (openvino_ep::BackendManager::GetGlobalContext().is_wholly_supported_graph)) {
+      try {
+        StartRemoteAsyncInference(context, infer_request);
+      } catch (std::string const& msg) {
+        throw msg;
       }
-      #else
-        try{
-          StartAsyncInference(context, infer_request);
-        } catch(std::string const & msg) {
-          throw msg;
-        }
-      #endif
-        try{
-          CompleteAsyncInference(context, infer_request);
-        }catch(std::string const & msg) {
-          throw msg;
-        }
-
-      // Get Output tensors
-      LOGS_DEFAULT(INFO) << log_tag << "Inference successful";
-      //Enable CI Logs
-      if (IsCILogEnabled()) {
-        std::cout << "Inference successful" << std::endl;
+    } else {
+      try {
+        StartAsyncInference(context, infer_request);
+      } catch (std::string const& msg) {
+        throw msg;
       }
+    }
+#else
+    try {
+      StartAsyncInference(context, infer_request);
+    } catch (std::string const& msg) {
+      throw msg;
+    }
+#endif
+    try {
+      CompleteAsyncInference(context, infer_request);
+    } catch (std::string const& msg) {
+      throw msg;
+    }
 
-      //Once the inference is completed, the infer_request becomes free and is placed back into pool of infer_requests_
-      inferRequestsQueue_->putIdleRequest(infer_request);
+    // Get Output tensors
+    LOGS_DEFAULT(INFO) << log_tag << "Inference successful";
+    // Enable CI Logs
+    if (IsCILogEnabled()) {
+      std::cout << "Inference successful" << std::endl;
+    }
+
+    // Once the inference is completed, the infer_request becomes free and is placed back into pool of infer_requests_
+    inferRequestsQueue_->putIdleRequest(infer_request);
 #ifndef NDEBUG
-  #ifndef IO_BUFFER_ENABLED // Printing performance counts is disabled when IO_BUFFER_ENABLED
+#ifndef IO_BUFFER_ENABLED  // Printing performance counts is disabled when IO_BUFFER_ENABLED
     if (openvino_ep::backend_utils::IsDebugEnabled()) {
-      inferRequestsQueue_->printstatus();  //Printing the elements of infer_requests_ vector pool only in debug mode
+      inferRequestsQueue_->printstatus();  // Printing the elements of infer_requests_ vector pool only in debug mode
       std::string& hw_target = (global_context_.device_id != "") ? global_context_.device_id : global_context_.device_type;
       printPerformanceCounts(infer_request, std::cout, hw_target);
     }
-  #endif
+#endif
 #endif
   }
 }

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -108,6 +108,16 @@ namespace onnxruntime {
         }
     }
 
+    void OVInferRequest::Infer() {
+        try {
+            ovInfReq.infer();
+        } catch (const Exception& e) {
+            throw std::string(log_tag + " Couldn't start Inference: " + e.what());
+        } catch (...) {
+            throw std::string(log_tag + " In Error Couldn't start Inference");
+        }
+    }
+
     void OVInferRequest::WaitRequest() {
         try {
             ovInfReq.wait();

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -69,6 +69,7 @@ typedef std::shared_ptr<OVTensor> OVTensorPtr;
         OVTensorPtr GetTensor(const std::string& name);
         void SetTensor(const std::string& name, OVTensorPtr& blob);
         void StartAsync();
+        void Infer();
         void WaitRequest();
         void QueryStatus();
         explicit OVInferRequest(ov::InferRequest obj) { ovInfReq = obj; }


### PR DESCRIPTION
### Description

- Allow dynamic shapes inference in GPU when enable_dynamic_shapes=True is set (Lines of interest: [Link 1](https://github.com/intel/onnxruntime/pull/290/files#diff-84b5dc31f64204b79173c207589103341ae50d58779a3e03092a6eb9b8e5cb7fL266) [Link 2](https://github.com/intel/onnxruntime/pull/290/files#diff-84b5dc31f64204b79173c207589103341ae50d58779a3e03092a6eb9b8e5cb7fR80) [Link 3](https://github.com/intel/onnxruntime/pull/290/files#diff-10ceae516462e95d43795fa0eb5ac08caa78e2e0ed0ed7491347ee840f8ca765R165)
- Add Synchronous inference API Infer(); Useful for debugging purposes (Files of interest: ov_interface.*)
- Added formatting changes in the files involved (Rest of the lines)
