### PR TITLE
Instantiate GlobalContext per Session object

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -13,22 +13,16 @@
 namespace onnxruntime {
 namespace openvino_ep {
 
-
 GlobalContext& BackendManager::GetGlobalContext() {
-  return *global_context_;
+  return global_context_;
 }
 
-void BackendManager::ReleaseGlobalContext() {
-  global_context_.reset();
-}
-
-BackendManager::BackendManager() {
-  global_context_ = std::make_unique<GlobalContext>();
-}
-
-void BackendManager::Initialize(const onnxruntime::Node& fused_node,
+BackendManager::BackendManager(const GlobalContext& global_context,
+                               const onnxruntime::Node& fused_node,
                                const onnxruntime::GraphViewer& subgraph,
                                const logging::Logger& logger) {
+  global_context_ = global_context;
+
   auto prec_str = GetGlobalContext().precision_str;
   if (prec_str == "FP32") {
     subgraph_context_.precision = "FP32";

--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -13,21 +13,20 @@
 namespace onnxruntime {
 namespace openvino_ep {
 
-static std::unique_ptr<GlobalContext> g_global_context;
 
 GlobalContext& BackendManager::GetGlobalContext() {
-  // This is not thread safe to call for the first time,
-  // but it is first called on the main thread by the constructor so it is safe.
-  if (!g_global_context)
-    g_global_context = std::make_unique<GlobalContext>();
-  return *g_global_context;
+  return *global_context_;
 }
 
 void BackendManager::ReleaseGlobalContext() {
-  g_global_context.reset();
+  global_context_.reset();
 }
 
-BackendManager::BackendManager(const onnxruntime::Node& fused_node,
+BackendManager::BackendManager() {
+  global_context_ = std::make_unique<GlobalContext>();
+}
+
+void BackendManager::Initialize(const onnxruntime::Node& fused_node,
                                const onnxruntime::GraphViewer& subgraph,
                                const logging::Logger& logger) {
   auto prec_str = GetGlobalContext().precision_str;

--- a/onnxruntime/core/providers/openvino/backend_manager.h
+++ b/onnxruntime/core/providers/openvino/backend_manager.h
@@ -18,14 +18,14 @@ namespace openvino_ep {
 // Singleton class that manages all the backends
 class BackendManager {
  public:
-  BackendManager();
-  void Initialize(const onnxruntime::Node& fused_node,
+  BackendManager(const GlobalContext& global_context,
+                 const onnxruntime::Node& fused_node,
                  const onnxruntime::GraphViewer& subgraph,
                  const logging::Logger& logger);
   void Compute(OrtKernelContext* context);
   void ShutdownBackendManager();
+  void SetGlobalCotext(const GlobalContext& global_context);
   GlobalContext& GetGlobalContext();
-  void ReleaseGlobalContext();
 
  private:
   std::unique_ptr<ONNX_NAMESPACE::ModelProto> GetModelProtoFromFusedNode(
@@ -46,7 +46,7 @@ class BackendManager {
   std::shared_ptr<IBackend> concrete_backend_;
   std::map<std::string, std::shared_ptr<IBackend>> backend_map_;
   SubGraphContext subgraph_context_;
-  std::unique_ptr<GlobalContext> global_context_;
+  GlobalContext global_context_;
 };
 
 }  // namespace openvino_ep

--- a/onnxruntime/core/providers/openvino/backend_manager.h
+++ b/onnxruntime/core/providers/openvino/backend_manager.h
@@ -18,13 +18,14 @@ namespace openvino_ep {
 // Singleton class that manages all the backends
 class BackendManager {
  public:
-  BackendManager(const onnxruntime::Node& fused_node,
+  BackendManager();
+  void Initialize(const onnxruntime::Node& fused_node,
                  const onnxruntime::GraphViewer& subgraph,
                  const logging::Logger& logger);
   void Compute(OrtKernelContext* context);
   void ShutdownBackendManager();
-  static GlobalContext& GetGlobalContext();
-  static void ReleaseGlobalContext();
+  GlobalContext& GetGlobalContext();
+  void ReleaseGlobalContext();
 
  private:
   std::unique_ptr<ONNX_NAMESPACE::ModelProto> GetModelProtoFromFusedNode(
@@ -45,6 +46,7 @@ class BackendManager {
   std::shared_ptr<IBackend> concrete_backend_;
   std::map<std::string, std::shared_ptr<IBackend>> backend_map_;
   SubGraphContext subgraph_context_;
+  std::unique_ptr<GlobalContext> global_context_;
 };
 
 }  // namespace openvino_ep

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -453,8 +453,7 @@ void BasicBackend::Infer(OrtKernelContext* ctx) {
 
 #ifdef IO_BUFFER_ENABLED
     if ((global_context_.device_type.find("GPU") != std::string::npos) &&
-        (global_context_.context != nullptr) &&
-        (openvino_ep::BackendManager::GetGlobalContext().is_wholly_supported_graph)) {
+        (global_context_.context != nullptr) && global_context_.is_wholly_supported_graph) {
       try {
         StartRemoteAsyncInference(context, infer_request);
       } catch (std::string const& msg) {

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -116,19 +116,23 @@ OpenVINOExecutionProvider::GetCapability(const GraphViewer& graph_viewer,
 
 #if defined(OPENVINO_2022_3)
   openvino_ep::GetCapability obj(graph_viewer,
-                                 backend_manager_->GetGlobalContext().device_type, "V_2022_3");
+                                 backend_manager_->GetGlobalContext().device_type,
+                                 backend_manager_->GetGlobalContext().precision_str, "V_2022_3");
   result = obj.Execute();
 #elif defined(OPENVINO_2023_0)
   openvino_ep::GetCapability obj(graph_viewer,
-                                 backend_manager_->GetGlobalContext().device_type, "V_2023_0");
+                                 backend_manager_->GetGlobalContext().device_type,
+                                 backend_manager_->GetGlobalContext().precision_str, "V_2023_0");
   result = obj.Execute();
 #elif defined(OPENVINO_2023_1)
   openvino_ep::GetCapability obj(graph_viewer,
-                                 backend_manager_->GetGlobalContext().device_type, "V_2023_1");
+                                 backend_manager_->GetGlobalContext().device_type,
+                                 backend_manager_->GetGlobalContext().precision_str, "V_2023_1");
   result = obj.Execute();
 #elif defined(OPENVINO_2023_2)
   openvino_ep::GetCapability obj(graph_viewer,
-                                 backend_manager_->GetGlobalContext().device_type, "V_2023_2");
+                                 backend_manager_->GetGlobalContext().device_type,
+                                 backend_manager_->GetGlobalContext().precision_str, "V_2023_2");
   result = obj.Execute();
 #endif
 

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -193,7 +193,9 @@ class OpenVINOExecutionProvider : public IExecutionProvider {
   const void* GetExecutionHandle() const noexcept override {
     return nullptr;
   }
-  std::shared_ptr<openvino_ep::BackendManager> backend_manager_;
+
+ private:
+  std::unique_ptr<openvino_ep::GlobalContext> global_context_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -193,6 +193,7 @@ class OpenVINOExecutionProvider : public IExecutionProvider {
   const void* GetExecutionHandle() const noexcept override {
     return nullptr;
   }
+  std::shared_ptr<openvino_ep::BackendManager> backend_manager_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -78,7 +78,7 @@ struct OpenVINO_Provider : Provider {
                                             // with this value at runtime.
     bool enable_opencl_throttling = false;  // [enable_opencl_throttling]: Enables OpenCL queue throttling for GPU
                                             // device (Reduces CPU Utilization when using GPU)
-    bool disable_dynamic_shapes = false;     // [disable_dynamic_shapes]:  Execute model with default static shape for optimal performance.
+    bool disable_dynamic_shapes = false;    // [disable_dynamic_shapes]:  Execute model with default static shape for optimal performance.
     void* context = nullptr;
 
     if (provider_options_map.find("device_type") != provider_options_map.end()) {
@@ -169,7 +169,6 @@ struct OpenVINO_Provider : Provider {
   }
 
   void Shutdown() override {
-    openvino_ep::BackendManager::ReleaseGlobalContext();
   }
 } g_provider;
 

--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -4,7 +4,7 @@
 #include "core/providers/shared_library/provider_api.h"
 #include "../backend_utils.h"
 #include "../backend_manager.h"
-#include "capabilities.h"
+#include "capability.h"
 #include "utils.h"
 
 #if defined(_MSC_VER)
@@ -111,7 +111,7 @@ std::vector<std::unique_ptr<ComputeCapability>> GetCapability::Execute() {
     if (backend_utils::IsCILogEnabled()) {
       std::cout << "Model is fully supported on OpenVINO" << std::endl;
     }
-    openvino_ep::BackendManager::GetGlobalContext().is_wholly_supported_graph = true;
+    is_wholly_supported_graph_ = true;
 
   } else {                                     // unsupported_nodes_idx.empty()
 #if defined(OPENVINO_DISABLE_GRAPH_PARTITION)  // disables graph partition at build time

--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -23,19 +23,21 @@ namespace onnxruntime {
 namespace openvino_ep {
 
 // Constructor
-GetCapability::GetCapability(const GraphViewer& graph_viewer_param, std::string device_type_param,
+GetCapability::GetCapability(const GraphViewer& graph_viewer_param,
+                             const std::string device_type_param,
+                             const std::string device_precision,
                              const std::string version_param)
-    : graph_viewer_(graph_viewer_param), device_type_(device_type_param) {
+    : graph_viewer_(graph_viewer_param), device_type_(device_type_param), device_precision_(device_precision) {
   if (version_param == "V_2022_3") {
-    data_ops_ = new DataOps(graph_viewer_, V_2022_3, device_type_);
+    data_ops_ = new DataOps(graph_viewer_, V_2022_3, device_type_, device_precision_);
   } else if (version_param == "V_2023_0") {
-    data_ops_ = new DataOps(graph_viewer_, V_2023_0, device_type_);
+    data_ops_ = new DataOps(graph_viewer_, V_2023_0, device_type_, device_precision_);
   } else if (version_param == "V_2023_1") {
-    data_ops_ = new DataOps(graph_viewer_, V_2023_1, device_type_);
+    data_ops_ = new DataOps(graph_viewer_, V_2023_1, device_type_, device_precision_);
   } else if (version_param == "V_2023_2") {
-    data_ops_ = new DataOps(graph_viewer_, V_2023_2, device_type_);
+    data_ops_ = new DataOps(graph_viewer_, V_2023_2, device_type_, device_precision_);
   } else {
-    data_ops_ = new DataOps(graph_viewer_, V_2023_2, device_type_);
+    data_ops_ = new DataOps(graph_viewer_, V_2023_2, device_type_, device_precision_);
   }
 }
 

--- a/onnxruntime/core/providers/openvino/ov_versions/capability.h
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.h
@@ -14,11 +14,15 @@ class GetCapability {
  private:
   const GraphViewer& graph_viewer_;
   std::string device_type_;
+  std::string device_precision_;
   DataOps* data_ops_;
   bool is_wholly_supported_graph_ = false;
 
  public:
-  GetCapability(const GraphViewer& graph_viewer_param, std::string device_type_param, const std::string version_param);
+  GetCapability(const GraphViewer& graph_viewer_param,
+                const std::string device_type_param,
+                const std::string precision,
+                const std::string version_param);
   virtual std::vector<std::unique_ptr<ComputeCapability>> Execute();
   bool IsWhollySupportedGraph() {
     return is_wholly_supported_graph_;

--- a/onnxruntime/core/providers/openvino/ov_versions/capability.h
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.h
@@ -15,10 +15,14 @@ class GetCapability {
   const GraphViewer& graph_viewer_;
   std::string device_type_;
   DataOps* data_ops_;
+  bool is_wholly_supported_graph_ = false;
 
  public:
   GetCapability(const GraphViewer& graph_viewer_param, std::string device_type_param, const std::string version_param);
   virtual std::vector<std::unique_ptr<ComputeCapability>> Execute();
+  bool IsWhollySupportedGraph() {
+    return is_wholly_supported_graph_;
+  }
 };
 
 }  // namespace openvino_ep

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -12,7 +12,7 @@
 #include "../backend_utils.h"
 #include "../backend_manager.h"
 #include "data_ops.h"
-#include "capabilities.h"
+#include "capability.h"
 #include "utils.h"
 
 #if defined(_MSC_VER)
@@ -637,54 +637,54 @@ void DataOps::populate_op_mode_supported() {
                              }};
     op_list_.insert({"Pow", obj});
   }
-  {
-    UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
-                             [this](const Node* node, const InitializedTensorSet&) {
-                               // Max op with one input is not supporting for GPU_FP16
-                               if (device_id_.find("GPU") != std::string::npos) {
-                                 auto prec_str = openvino_ep::BackendManager::GetGlobalContext().precision_str;
-                                 if (prec_str == "FP16") {
-                                   if (node->InputDefs().size() == 1) {
-                                     return true;
-                                   }
-                                 }
-                               }
-                               return false;
-                             }};
-    op_list_.insert({"Max", obj});
-  }
-  {
-    UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
-                             [this](const Node* node, const InitializedTensorSet&) {
-                               // Min op with one input is not supporting for GPU_FP16
-                               if (device_id_.find("GPU") != std::string::npos) {
-                                 auto prec_str = openvino_ep::BackendManager::GetGlobalContext().precision_str;
-                                 if (prec_str == "FP16") {
-                                   if (node->InputDefs().size() == 1) {
-                                     return true;
-                                   }
-                                 }
-                               }
-                               return false;
-                             }};
-    op_list_.insert({"Min", obj});
-  }
-  {
-    UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
-                             [this](const Node* node, const InitializedTensorSet&) {
-                               // Sum op with one input is not supporting for GPU_FP16
-                               if (device_id_.find("GPU") != std::string::npos) {
-                                 auto prec_str = openvino_ep::BackendManager::GetGlobalContext().precision_str;
-                                 if (prec_str == "FP16") {
-                                   if (node->InputDefs().size() == 1) {
-                                     return true;
-                                   }
-                                 }
-                               }
-                               return false;
-                             }};
-    op_list_.insert({"Sum", obj});
-  }
+  // {
+  //   UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
+  //                            [this](const Node* node, const InitializedTensorSet&) {
+  //                              // Max op with one input is not supporting for GPU_FP16
+  //                              if (device_id_.find("GPU") != std::string::npos) {
+  //                                auto prec_str = openvino_ep::BackendManager::GetGlobalContext().precision_str;
+  //                                if (prec_str == "FP16") {
+  //                                  if (node->InputDefs().size() == 1) {
+  //                                    return true;
+  //                                  }
+  //                                }
+  //                              }
+  //                              return false;
+  //                            }};
+  //   op_list_.insert({"Max", obj});
+  // }
+  // {
+  //   UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
+  //                            [this](const Node* node, const InitializedTensorSet&) {
+  //                              // Min op with one input is not supporting for GPU_FP16
+  //                              if (device_id_.find("GPU") != std::string::npos) {
+  //                                auto prec_str = openvino_ep::BackendManager::GetGlobalContext().precision_str;
+  //                                if (prec_str == "FP16") {
+  //                                  if (node->InputDefs().size() == 1) {
+  //                                    return true;
+  //                                  }
+  //                                }
+  //                              }
+  //                              return false;
+  //                            }};
+  //   op_list_.insert({"Min", obj});
+  // }
+  // {
+  //   UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
+  //                            [this](const Node* node, const InitializedTensorSet&) {
+  //                              // Sum op with one input is not supporting for GPU_FP16
+  //                              if (device_id_.find("GPU") != std::string::npos) {
+  //                                auto prec_str = openvino_ep::BackendManager::GetGlobalContext().precision_str;
+  //                                if (prec_str == "FP16") {
+  //                                  if (node->InputDefs().size() == 1) {
+  //                                    return true;
+  //                                  }
+  //                                }
+  //                              }
+  //                              return false;
+  //                            }};
+  //   op_list_.insert({"Sum", obj});
+  // }
   {
     UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
                              [this](const Node* node, const InitializedTensorSet& initializers) {

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -637,54 +637,51 @@ void DataOps::populate_op_mode_supported() {
                              }};
     op_list_.insert({"Pow", obj});
   }
-  // {
-  //   UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
-  //                            [this](const Node* node, const InitializedTensorSet&) {
-  //                              // Max op with one input is not supporting for GPU_FP16
-  //                              if (device_id_.find("GPU") != std::string::npos) {
-  //                                auto prec_str = openvino_ep::BackendManager::GetGlobalContext().precision_str;
-  //                                if (prec_str == "FP16") {
-  //                                  if (node->InputDefs().size() == 1) {
-  //                                    return true;
-  //                                  }
-  //                                }
-  //                              }
-  //                              return false;
-  //                            }};
-  //   op_list_.insert({"Max", obj});
-  // }
-  // {
-  //   UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
-  //                            [this](const Node* node, const InitializedTensorSet&) {
-  //                              // Min op with one input is not supporting for GPU_FP16
-  //                              if (device_id_.find("GPU") != std::string::npos) {
-  //                                auto prec_str = openvino_ep::BackendManager::GetGlobalContext().precision_str;
-  //                                if (prec_str == "FP16") {
-  //                                  if (node->InputDefs().size() == 1) {
-  //                                    return true;
-  //                                  }
-  //                                }
-  //                              }
-  //                              return false;
-  //                            }};
-  //   op_list_.insert({"Min", obj});
-  // }
-  // {
-  //   UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
-  //                            [this](const Node* node, const InitializedTensorSet&) {
-  //                              // Sum op with one input is not supporting for GPU_FP16
-  //                              if (device_id_.find("GPU") != std::string::npos) {
-  //                                auto prec_str = openvino_ep::BackendManager::GetGlobalContext().precision_str;
-  //                                if (prec_str == "FP16") {
-  //                                  if (node->InputDefs().size() == 1) {
-  //                                    return true;
-  //                                  }
-  //                                }
-  //                              }
-  //                              return false;
-  //                            }};
-  //   op_list_.insert({"Sum", obj});
-  // }
+  {
+    UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
+                             [this](const Node* node, const InitializedTensorSet&) {
+                               // Max op with one input is not supporting for GPU_FP16
+                               if (device_id_.find("GPU") != std::string::npos) {
+                                 if (device_precision_ == "FP16") {
+                                   if (node->InputDefs().size() == 1) {
+                                     return true;
+                                   }
+                                 }
+                               }
+                               return false;
+                             }};
+    op_list_.insert({"Max", obj});
+  }
+  {
+    UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
+                             [this](const Node* node, const InitializedTensorSet&) {
+                               // Min op with one input is not supporting for GPU_FP16
+                               if (device_id_.find("GPU") != std::string::npos) {
+                                 if (device_precision_ == "FP16") {
+                                   if (node->InputDefs().size() == 1) {
+                                     return true;
+                                   }
+                                 }
+                               }
+                               return false;
+                             }};
+    op_list_.insert({"Min", obj});
+  }
+  {
+    UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
+                             [this](const Node* node, const InitializedTensorSet&) {
+                               // Sum op with one input is not supporting for GPU_FP16
+                               if (device_id_.find("GPU") != std::string::npos) {
+                                 if (device_precision_ == "FP16") {
+                                   if (node->InputDefs().size() == 1) {
+                                     return true;
+                                   }
+                                 }
+                               }
+                               return false;
+                             }};
+    op_list_.insert({"Sum", obj});
+  }
   {
     UnsupportedOpMode obj = {{V_2022_1, V_2022_2, V_2022_3},
                              [this](const Node* node, const InitializedTensorSet& initializers) {

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.h
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.h
@@ -50,6 +50,7 @@ class DataOps {
   const GraphViewer& graph_viewer_;
   VersionNum version_id_;
   std::string device_id_;
+  std::string device_precision_;
   std::multimap<std::string, UnsupportedOpMode> op_list_;
   std::vector<SupportedOp> subgraph_supported_;
   std::vector<SupportedOp> no_dimension_supported_;
@@ -70,8 +71,8 @@ class DataOps {
                          const NodeIndex node_idx);
 
  public:
-  DataOps(const GraphViewer& graph_viewer_param, VersionNum ver, std::string dev_id)
-      : graph_viewer_(graph_viewer_param), version_id_(ver), device_id_(dev_id) {
+  DataOps(const GraphViewer& graph_viewer_param, VersionNum ver, const std::string dev_id, const std::string device_precision)
+      : graph_viewer_(graph_viewer_param), version_id_(ver), device_id_(dev_id), device_precision_(device_precision) {
     populate_op_mode_supported();
     populate_types_supported();
   }

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1449,10 +1449,10 @@ ProviderOptions OrtOpenVINOProviderOptionsToOrtOpenVINOProviderOptionsV2(const O
   ov_options_converted_map["context"] = context_string.str();
 
   ov_options_converted_map["enable_opencl_throttling"] = legacy_ov_options->enable_opencl_throttling;
-  std::string enable_dynamic_shapes = reinterpret_cast<const char*> (legacy_ov_options->enable_dynamic_shapes);
-  if(enable_dynamic_shapes=="true" || enable_dynamic_shapes=="True"){
+  std::string enable_dynamic_shapes = reinterpret_cast<const char*>(legacy_ov_options->enable_dynamic_shapes);
+  if (enable_dynamic_shapes == "true" || enable_dynamic_shapes == "True") {
     ov_options_converted_map["disable_dynamic_shapes"] = "false";
-  }else if(enable_dynamic_shapes=="false" || enable_dynamic_shapes=="False"){
+  } else if (enable_dynamic_shapes == "false" || enable_dynamic_shapes == "False") {
     ov_options_converted_map["disable_dynamic_shapes"] = "true";
   }
   // Add new provider option below

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -74,7 +74,7 @@ def _openvino_verify_device_type(device_read):
         "GPU_FP32_NO_PARTITION",
         "GPU_FP16_NO_PARTITION",
         "NPU_FP16_NO_PARTITION",
-        "NPU_U8_NO_PARTITION"
+        "NPU_U8_NO_PARTITION",
     ]
     status_hetero = True
     res = False


### PR DESCRIPTION
This PR fixes a bug and ensures that the attributes in the global context don't get overwritten when an user creates more than one session with different provider options for OpenVINO.

