### PR TITLE
Export/Import OV Compiled blobs as EPContext Models

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.h
+++ b/onnxruntime/core/providers/openvino/backend_manager.h
@@ -10,6 +10,7 @@
 
 #include "ov_interface.h"
 #include "contexts.h"
+#include "onnx_ctx_model_helper.h"
 #include "ibackend.h"
 
 namespace onnxruntime {
@@ -21,11 +22,15 @@ class BackendManager {
   BackendManager(const GlobalContext& global_context,
                  const onnxruntime::Node& fused_node,
                  const onnxruntime::GraphViewer& subgraph,
-                 const logging::Logger& logger);
+                 const logging::Logger& logger,
+                 EPCtxHandler& ctx_handle);
   void Compute(OrtKernelContext* context);
   void ShutdownBackendManager();
   void SetGlobalCotext(const GlobalContext& global_context);
   GlobalContext& GetGlobalContext();
+  Status ExportCompiledBlobAsEPCtxNode(const onnxruntime::Node& fused_node,
+                                       const onnxruntime::GraphViewer& subgraph,
+                                       const logging::Logger& logger);
 
  private:
   std::unique_ptr<ONNX_NAMESPACE::ModelProto> GetModelProtoFromFusedNode(
@@ -47,6 +52,8 @@ class BackendManager {
   std::map<std::string, std::shared_ptr<IBackend>> backend_map_;
   SubGraphContext subgraph_context_;
   GlobalContext global_context_;
+  EPCtxHandler ep_ctx_handle_{};
+  std::string openvino_sdk_version_{};
 };
 
 }  // namespace openvino_ep

--- a/onnxruntime/core/providers/openvino/backend_manager.h
+++ b/onnxruntime/core/providers/openvino/backend_manager.h
@@ -28,8 +28,7 @@ class BackendManager {
   void ShutdownBackendManager();
   void SetGlobalCotext(const GlobalContext& global_context);
   GlobalContext& GetGlobalContext();
-  Status ExportCompiledBlobAsEPCtxNode(const onnxruntime::Node& fused_node,
-                                       const onnxruntime::GraphViewer& subgraph,
+  Status ExportCompiledBlobAsEPCtxNode(const onnxruntime::GraphViewer& subgraph,
                                        const logging::Logger& logger);
 
  private:

--- a/onnxruntime/core/providers/openvino/backends/backend_factory.cc
+++ b/onnxruntime/core/providers/openvino/backends/backend_factory.cc
@@ -13,7 +13,8 @@ namespace openvino_ep {
 std::shared_ptr<IBackend>
 BackendFactory::MakeBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                             GlobalContext& global_context,
-                            const SubGraphContext& subgraph_context) {
+                            const SubGraphContext& subgraph_context,
+                            EPCtxHandler& ep_ctx_handle) {
   std::string type = global_context.device_type;
   if (type == "CPU" || type.find("GPU") != std::string::npos ||
       type.find("NPU") != std::string::npos ||
@@ -22,7 +23,7 @@ BackendFactory::MakeBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
       type.find("AUTO") != std::string::npos) {
     std::shared_ptr<IBackend> concrete_backend_;
     try {
-      concrete_backend_ = std::make_shared<BasicBackend>(model_proto, global_context, subgraph_context);
+      concrete_backend_ = std::make_shared<BasicBackend>(model_proto, global_context, subgraph_context, ep_ctx_handle);
     } catch (std::string const& msg) {
       ORT_THROW(msg);
     }

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -25,12 +25,15 @@ class BasicBackend : public IBackend {
  public:
   BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                GlobalContext& global_context,
-               const SubGraphContext& subgraph_context);
+               const SubGraphContext& subgraph_context,
+               EPCtxHandler& ep_ctx_handle);
 
   void Infer(OrtKernelContext* context) override;
+  ov::CompiledModel& GetOVCompiledModel() override {
+    return exe_network_.Get();
+  }
 
  private:
-  bool ImportBlob(std::string hw_target, bool npu_status);
   void PopulateCompiledDirectory(std::string, std::string&, std::string&, bool&);
   bool ValidateSubgraph(std::map<std::string, std::shared_ptr<ov::Node>>& const_outputs_map);
   void PopulateConfigValue(ov::AnyMap& device_config);
@@ -49,10 +52,11 @@ class BasicBackend : public IBackend {
   GlobalContext& global_context_;
   SubGraphContext subgraph_context_;
   mutable std::mutex compute_lock_;
-  std::shared_ptr<OVNetwork> ie_cnn_network_;
+  std::shared_ptr<const OVNetwork> ie_cnn_network_;
   OVExeNetwork exe_network_;
   std::map<std::string, std::shared_ptr<ov::Node>> const_outputs_map_;
   std::unique_ptr<InferRequestsQueue> inferRequestsQueue_;
+  bool is_ep_ctx_graph_{false};
 #if defined IO_BUFFER_ENABLED
   OVRemoteContextPtr remote_context_;
 #endif

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -18,6 +18,7 @@ struct GlobalContext {
   bool enable_npu_fast_compile = false;
   bool enable_opencl_throttling = false;
   bool disable_dynamic_shapes = false;
+  bool ep_context_embed_mode = true;
   size_t num_of_threads;
   std::string device_type;
   std::string precision_str;

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -19,6 +19,7 @@ struct GlobalContext {
   bool enable_opencl_throttling = false;
   bool disable_dynamic_shapes = false;
   bool ep_context_embed_mode = true;
+  bool export_ep_ctx_blob = false;
   size_t num_of_threads;
   std::string device_type;
   std::string precision_str;

--- a/onnxruntime/core/providers/openvino/ibackend.h
+++ b/onnxruntime/core/providers/openvino/ibackend.h
@@ -6,6 +6,7 @@
 #include <memory>
 #define ORT_API_MANUAL_INIT
 #include "core/session/onnxruntime_cxx_api.h"
+#include "onnx_ctx_model_helper.h"
 
 namespace onnxruntime {
 namespace openvino_ep {
@@ -13,6 +14,7 @@ namespace openvino_ep {
 class IBackend {
  public:
   virtual void Infer(OrtKernelContext* context) = 0;
+  virtual ov::CompiledModel& GetOVCompiledModel() = 0;
 };
 
 class BackendFactory {
@@ -20,7 +22,8 @@ class BackendFactory {
   static std::shared_ptr<IBackend>
   MakeBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
               GlobalContext& global_context,
-              const SubGraphContext& subgraph_context);
+              const SubGraphContext& subgraph_context,
+              EPCtxHandler& ctx_handle);
 };
 
 }  // namespace openvino_ep

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
@@ -14,14 +14,13 @@ namespace openvino_ep {
  */
 
 Status EPCtxHandler::ExportEPCtxModel(const GraphViewer& graph_viewer,
-                                      const onnxruntime::Node& fused_node,
+                                      const std::string& graph_name,
                                       const logging::Logger& logger,
                                       const bool& ep_context_embed_mode,
                                       const std::string& model_blob_str,
                                       const std::string& openvino_sdk_version) const {
   auto model_build = graph_viewer.CreateModel(logger);
   auto& graph_build = model_build->MainGraph();
-  std::string graph_name = fused_node.Name();
 
   // Get graph inputs and outputs
   std::vector<onnxruntime::NodeArg*> inputs, outputs;

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
@@ -1,0 +1,121 @@
+// Copyright (C) Intel Corporation
+// Licensed under the MIT License
+
+#include <string>
+#include <fstream>
+
+#include "onnx_ctx_model_helper.h"
+
+namespace onnxruntime {
+namespace openvino_ep {
+
+/* Export the serialized blob string embedded onto an EPContext Node
+ * along with other metadata necessary to validate the graph on import
+ */
+
+Status EPCtxHandler::ExportEPCtxModel(const GraphViewer& graph_viewer,
+                                      const onnxruntime::Node& fused_node,
+                                      const logging::Logger& logger,
+                                      const bool& ep_context_embed_mode,
+                                      const std::string& model_blob_str,
+                                      const std::string& openvino_sdk_version) const {
+  auto model_build = graph_viewer.CreateModel(logger);
+  auto& graph_build = model_build->MainGraph();
+  std::string graph_name = fused_node.Name();
+
+  // Get graph inputs and outputs
+  std::vector<onnxruntime::NodeArg*> inputs, outputs;
+  for (auto input : graph_viewer.GetInputs()) {
+    auto& n_input = graph_build.GetOrCreateNodeArg(input->Name(), input->TypeAsProto());
+    inputs.push_back(&n_input);
+  }
+  for (auto output : graph_viewer.GetOutputs()) {
+    auto& n_output = graph_build.GetOrCreateNodeArg(output->Name(), output->TypeAsProto());
+    outputs.push_back(&n_output);
+  }
+
+  // Create EP context node attributes
+  auto attr_0 = ONNX_NAMESPACE::AttributeProto::Create();
+  auto attr_1 = ONNX_NAMESPACE::AttributeProto::Create();
+  auto attr_2 = ONNX_NAMESPACE::AttributeProto::Create();
+  auto attr_3 = ONNX_NAMESPACE::AttributeProto::Create();
+
+  // embed mode
+  attr_0->set_name(EMBED_MODE);
+  attr_0->set_type(onnx::AttributeProto_AttributeType_INT);
+  attr_0->set_i(ep_context_embed_mode);
+  // ep context
+  attr_1->set_name(EP_CACHE_CONTEXT);
+  attr_1->set_type(onnx::AttributeProto_AttributeType_STRING);
+  attr_1->set_s(model_blob_str);
+  // sdk version
+  attr_2->set_name(EP_SDK_VER);
+  attr_2->set_type(onnx::AttributeProto_AttributeType_STRING);
+  attr_2->set_s(openvino_sdk_version);
+  // source
+  attr_3->set_name(SOURCE);
+  attr_3->set_type(onnx::AttributeProto_AttributeType_STRING);
+  attr_3->set_s(kOpenVINOExecutionProvider);
+
+  auto node_attributes = ONNX_NAMESPACE::NodeAttributes::Create();
+  node_attributes->reserve(4);
+  node_attributes->emplace(EMBED_MODE, *attr_0);
+  node_attributes->emplace(EP_CACHE_CONTEXT, *attr_1);
+  node_attributes->emplace(EP_SDK_VER, *attr_2);
+  node_attributes->emplace(SOURCE, *attr_3);
+
+  // Create EP context node
+  graph_build.AddNode(graph_name, EPCONTEXT_OP, "", inputs, outputs, node_attributes.get(), kMSDomain);
+  ORT_ENFORCE(graph_build.Resolve().IsOK());
+
+  // Serialize modelproto to string
+  auto new_graph_viewer = graph_build.CreateGraphViewer();
+  auto model = new_graph_viewer->CreateModel(logger);
+  auto model_proto = model->ToProto();
+  new_graph_viewer->ToProto(*model_proto->mutable_graph(), true, true);
+  model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+
+  // Finally, dump the model
+  std::ofstream dump(graph_name + "-ov_blob.onnx", std::ios::out | std::ios::trunc | std::ios::binary);
+  model_proto->SerializeToOstream(dump);
+
+  LOGS_DEFAULT(VERBOSE) << "[OpenVINO EP] Export blob as EPContext Node";
+
+  return Status::OK();
+}
+
+Status EPCtxHandler::ImportBlobFromEPCtxModel(const GraphViewer& graph_viewer) {
+  auto node = graph_viewer.GetNode(0);
+  auto& attrs = node->GetAttributes();
+  ORT_ENFORCE(attrs.count(EP_CACHE_CONTEXT) > 0);
+
+  blob_serialized_ = attrs.at(EP_CACHE_CONTEXT).s();
+
+  LOGS_DEFAULT(VERBOSE) << "[OpenVINO EP] Read blob from EPContext Node";
+
+  is_valid_ep_ctx_graph_ = true;
+  return Status::OK();
+}
+
+bool EPCtxHandler::CheckForOVEPCtxNode(const GraphViewer& graph_viewer, std::string openvino_sdk_version) const {
+  for (int i = 0; i < graph_viewer.MaxNodeIndex(); ++i) {
+    auto node = graph_viewer.GetNode(i);
+    auto& attrs = node->GetAttributes();
+
+    // Check for correct Op Type, EP SOURCE, and SDK version
+    if (node != nullptr && node->OpType() == EPCONTEXT_OP) {
+      if (attrs.at(SOURCE).s() == kOpenVINOExecutionProvider) {
+        if (attrs.at(EP_SDK_VER).s() == openvino_sdk_version) {
+          return true;
+        } else {
+          ORT_THROW("[Invalid Graph] Versions of OpenVINO used to export blob (" + attrs.at(EP_SDK_VER).s() +
+                    ") and current runtime (" + openvino_sdk_version + ") don't match.");
+        }
+      }
+    }
+  }
+  return false;
+}
+
+}  // namespace openvino_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
@@ -1,0 +1,42 @@
+// Copyright (C) Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+
+#include <sstream>
+
+#include "core/providers/shared_library/provider_api.h"
+
+namespace onnxruntime {
+namespace openvino_ep {
+
+// Utilities to handle EPContext node export and parsing of an EPContext node
+// to create the compiled_model object to infer on
+static const std::string EPCONTEXT_OP = "EPContext";
+static const std::string EMBED_MODE = "embed_mode";
+static const std::string EP_CACHE_CONTEXT = "ep_cache_context";
+static const std::string EP_SDK_VER = "ep_sdk_version";
+static const std::string SOURCE = "source";
+
+class EPCtxHandler {
+ public:
+  EPCtxHandler() = default;
+  EPCtxHandler(const EPCtxHandler&) = default;
+  Status ExportEPCtxModel(const GraphViewer& graph_viewer,
+                          const onnxruntime::Node& fused_node,
+                          const logging::Logger& logger,
+                          const bool& ep_context_embed_mode,
+                          const std::string& model_blob_str,
+                          const std::string& openvino_sdk_version) const;
+  Status ImportBlobFromEPCtxModel(const GraphViewer& graph_viewer);
+  bool CheckForOVEPCtxNode(const GraphViewer& graph_viewer, std::string openvino_sdk_version) const;
+  bool IsValidOVEPCtxGraph() const {return is_valid_ep_ctx_graph_;};
+  [[nodiscard]] const std::string& GetModelBlobString() const { return blob_serialized_; }
+
+ private:
+  bool is_valid_ep_ctx_graph_{false};
+  std::string blob_serialized_{};
+};
+
+}  // namespace openvino_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
@@ -30,7 +30,7 @@ class EPCtxHandler {
                           const std::string& openvino_sdk_version) const;
   Status ImportBlobFromEPCtxModel(const GraphViewer& graph_viewer);
   bool CheckForOVEPCtxNode(const GraphViewer& graph_viewer, std::string openvino_sdk_version) const;
-  bool IsValidOVEPCtxGraph() const {return is_valid_ep_ctx_graph_;};
+  bool IsValidOVEPCtxGraph() const { return is_valid_ep_ctx_graph_; };
   [[nodiscard]] const std::string& GetModelBlobString() const { return blob_serialized_; }
 
  private:

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
@@ -23,7 +23,7 @@ class EPCtxHandler {
   EPCtxHandler() = default;
   EPCtxHandler(const EPCtxHandler&) = default;
   Status ExportEPCtxModel(const GraphViewer& graph_viewer,
-                          const onnxruntime::Node& fused_node,
+                          const std::string& graph_name,
                           const logging::Logger& logger,
                           const bool& ep_context_embed_mode,
                           const std::string& model_blob_str,

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -29,6 +29,7 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProv
   global_context_->disable_dynamic_shapes = info.disable_dynamic_shapes_;
   global_context_->num_of_threads = info.num_of_threads_;
   global_context_->OpenVINO_Version = {OPENVINO_VERSION_MAJOR, OPENVINO_VERSION_MINOR};
+  global_context_->export_ep_ctx_blob = info.export_ep_ctx_blob_;
 
   // to check if target device is available
   // using ie_core capability GetAvailableDevices to fetch list of devices plugged in
@@ -157,9 +158,8 @@ common::Status OpenVINOExecutionProvider::Compile(
                                                       *GetLogger(),
                                                       ep_ctx_handle_);
 
-    bool EXPORT_PRECOMPILED_BLOB = false;
 
-    if (EXPORT_PRECOMPILED_BLOB && !ep_ctx_handle_.IsValidOVEPCtxGraph()) {
+    if (global_context_->export_ep_ctx_blob && !ep_ctx_handle_.IsValidOVEPCtxGraph()) {
       ORT_RETURN_IF_ERROR(backend_manager->ExportCompiledBlobAsEPCtxNode(fused_node,
                                                                          graph_body_viewer,
                                                                          *GetLogger()));

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -158,7 +158,6 @@ common::Status OpenVINOExecutionProvider::Compile(
                                                       *GetLogger(),
                                                       ep_ctx_handle_);
 
-
     if (global_context_->export_ep_ctx_blob && !ep_ctx_handle_.IsValidOVEPCtxGraph()) {
       ORT_RETURN_IF_ERROR(backend_manager->ExportCompiledBlobAsEPCtxNode(fused_node,
                                                                          graph_body_viewer,

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -190,6 +190,7 @@ class OpenVINOExecutionProvider : public IExecutionProvider {
 
  private:
   std::unique_ptr<openvino_ep::GlobalContext> global_context_;
+  openvino_ep::EPCtxHandler ep_ctx_handle_{};
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -70,11 +70,12 @@ struct OpenVINOExecutionProviderInfo {
   void* context_;
   bool enable_opencl_throttling_;
   bool disable_dynamic_shapes_;
+  bool export_ep_ctx_blob_;
 
   explicit OpenVINOExecutionProviderInfo(std::string dev_type, bool enable_npu_fast_compile, std::string dev_id,
                                          size_t num_of_threads, std::string cache_dir, int num_streams,
                                          void* context, bool enable_opencl_throttling,
-                                         bool disable_dynamic_shapes)
+                                         bool disable_dynamic_shapes, bool export_ep_ctx_blob)
       : enable_npu_fast_compile_(enable_npu_fast_compile),
         device_id_(dev_id),
         num_of_threads_(num_of_threads),
@@ -82,7 +83,8 @@ struct OpenVINOExecutionProviderInfo {
         num_streams_(num_streams),
         context_(context),
         enable_opencl_throttling_(enable_opencl_throttling),
-        disable_dynamic_shapes_(disable_dynamic_shapes) {
+        disable_dynamic_shapes_(disable_dynamic_shapes),
+        export_ep_ctx_blob_(export_ep_ctx_blob) {
     if (dev_type == "") {
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
                          << "No runtime device selection option provided.";
@@ -160,7 +162,7 @@ struct OpenVINOExecutionProviderInfo {
                        << "Choosing Device: " << device_type_ << " , Precision: " << precision_;
   }
   OpenVINOExecutionProviderInfo() {
-    OpenVINOExecutionProviderInfo("", false, "", 0, "", 1, NULL, false, false);
+    OpenVINOExecutionProviderInfo("", false, "", 0, "", 1, NULL, false, false, false);
   }
 };
 

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -81,7 +81,7 @@ struct OpenVINO_Provider : Provider {
                                             // with this value at runtime.
     bool enable_opencl_throttling = false;  // [enable_opencl_throttling]: Enables OpenCL queue throttling for GPU
                                             // device (Reduces CPU Utilization when using GPU)
-    bool export_ep_ctx_blob = false;       // Whether to export the pre-compiled blob as an EPContext model.
+    bool export_ep_ctx_blob = false;        // Whether to export the pre-compiled blob as an EPContext model.
 
     void* context = nullptr;
 

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -11,13 +11,15 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
   OpenVINOProviderFactory(const char* device_type, bool enable_npu_fast_compile,
                           const char* device_id, size_t num_of_threads,
                           const char* cache_dir, int num_streams, void* context,
-                          bool enable_opencl_throttling, bool disable_dynamic_shapes)
+                          bool enable_opencl_throttling, bool disable_dynamic_shapes,
+                          bool export_ep_ctx_blob)
       : enable_npu_fast_compile_(enable_npu_fast_compile),
         num_of_threads_(num_of_threads),
         num_streams_(num_streams),
         context_(context),
         enable_opencl_throttling_(enable_opencl_throttling),
-        disable_dynamic_shapes_(disable_dynamic_shapes) {
+        disable_dynamic_shapes_(disable_dynamic_shapes),
+        export_ep_ctx_blob_(export_ep_ctx_blob) {
     device_type_ = (device_type == nullptr) ? "" : device_type;
     device_id_ = (device_id == nullptr) ? "" : device_id;
     cache_dir_ = (cache_dir == nullptr) ? "" : cache_dir;
@@ -37,12 +39,13 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
   void* context_;
   bool enable_opencl_throttling_;
   bool disable_dynamic_shapes_;
+  bool export_ep_ctx_blob_;
 };
 
 std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {
   OpenVINOExecutionProviderInfo info(device_type_, enable_npu_fast_compile_, device_id_, num_of_threads_,
                                      cache_dir_, num_streams_, context_, enable_opencl_throttling_,
-                                     disable_dynamic_shapes_);
+                                     disable_dynamic_shapes_, export_ep_ctx_blob_);
   return std::make_unique<OpenVINOExecutionProvider>(info);
 }
 
@@ -78,6 +81,8 @@ struct OpenVINO_Provider : Provider {
                                             // with this value at runtime.
     bool enable_opencl_throttling = false;  // [enable_opencl_throttling]: Enables OpenCL queue throttling for GPU
                                             // device (Reduces CPU Utilization when using GPU)
+    bool export_ep_ctx_blob = false;       // Whether to export the pre-compiled blob as an EPContext model.
+
     void* context = nullptr;
 
     if (provider_options_map.find("device_type") != provider_options_map.end()) {
@@ -165,6 +170,15 @@ struct OpenVINO_Provider : Provider {
         }
       }
     }
+
+    if (provider_options_map.find("export_ep_ctx_blob") != provider_options_map.end()) {
+      bool_flag = provider_options_map.at("export_ep_ctx_blob");
+      if (bool_flag == "true" || bool_flag == "True")
+        export_ep_ctx_blob = true;
+      else if (bool_flag == "false" || bool_flag == "False")
+        export_ep_ctx_blob = false;
+      bool_flag = "";
+    }
     return std::make_shared<OpenVINOProviderFactory>(const_cast<char*>(device_type.c_str()),
                                                      enable_npu_fast_compile,
                                                      device_id,
@@ -173,7 +187,8 @@ struct OpenVINO_Provider : Provider {
                                                      num_streams,
                                                      context,
                                                      enable_opencl_throttling,
-                                                     disable_dynamic_shapes);
+                                                     disable_dynamic_shapes,
+                                                     export_ep_ctx_blob);
   }
 
   void Initialize() override {

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -41,13 +41,13 @@ class OVCore {
  public:
   std::shared_ptr<OVNetwork> ReadModel(const std::string& model_stream, const std::string& model_path) const;
   OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
-                           std::string& hw_target,
-                           ov::AnyMap& device_config,
-                           std::string name);
+                            std::string& hw_target,
+                            ov::AnyMap& device_config,
+                            std::string name);
   OVExeNetwork CompileModel(const std::string model_path,
-                           std::string& hw_target,
-                           ov::AnyMap& device_config,
-                           std::string name);
+                            std::string& hw_target,
+                            ov::AnyMap& device_config,
+                            std::string name);
   OVExeNetwork ImportModel(std::istringstream& model_stream,
                            std::string& hw_target,
                            ov::AnyMap& device_config,
@@ -58,7 +58,7 @@ class OVCore {
 #endif
   std::vector<std::string> GetAvailableDevices();
   void SetCache(std::string cache_dir_path);
-  ov::Core& Get() {return oe;}
+  ov::Core& Get() { return oe; }
   void SetStreams(const std::string& device_type, int num_streams);
 };
 
@@ -66,8 +66,8 @@ class OVExeNetwork {
   ov::CompiledModel obj;
 
  public:
-  explicit OVExeNetwork(ov::CompiledModel md): obj(md) {}
-  OVExeNetwork(): obj(ov::CompiledModel()) {}
+  explicit OVExeNetwork(ov::CompiledModel md) : obj(md) {}
+  OVExeNetwork() : obj(ov::CompiledModel()) {}
   ov::CompiledModel& Get() { return obj; }
   OVInferRequest CreateInferRequest();
 };
@@ -82,8 +82,8 @@ class OVInferRequest {
   void Infer();
   void WaitRequest();
   void QueryStatus();
-  explicit OVInferRequest(ov::InferRequest obj): ovInfReq(obj) {}
-  OVInferRequest(): ovInfReq(ov::InferRequest()) {}
+  explicit OVInferRequest(ov::InferRequest obj) : ovInfReq(obj) {}
+  OVInferRequest() : ovInfReq(ov::InferRequest()) {}
   ov::InferRequest& GetNewObj() {
     return ovInfReq;
   }

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -5,6 +5,8 @@
 
 #include <vector>
 #include <memory>
+#include <fstream>
+#include <sstream>
 
 #include "openvino/openvino.hpp"
 #include "openvino/pass/convert_fp32_to_fp16.hpp"
@@ -38,22 +40,25 @@ class OVCore {
 
  public:
   std::shared_ptr<OVNetwork> ReadModel(const std::string& model_stream, const std::string& model_path) const;
-  OVExeNetwork LoadNetwork(std::shared_ptr<OVNetwork>& ie_cnn_network,
+  OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
                            std::string& hw_target,
                            ov::AnyMap& device_config,
                            std::string name);
-  OVExeNetwork LoadNetwork(const std::string model_path,
+  OVExeNetwork CompileModel(const std::string model_path,
                            std::string& hw_target,
                            ov::AnyMap& device_config,
                            std::string name);
-  void SetCache(std::string cache_dir_path);
+  OVExeNetwork ImportModel(std::istringstream& model_stream,
+                           std::string& hw_target,
+                           ov::AnyMap& device_config,
+                           std::string name);
 #ifdef IO_BUFFER_ENABLED
-  OVExeNetwork LoadNetwork(std::shared_ptr<OVNetwork>& model, OVRemoteContextPtr context, std::string& name);
+  OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& model, OVRemoteContextPtr context, std::string& name);
+  OVExeNetwork ImportModel(std::istringstream& model_stream, OVRemoteContextPtr context, std::string& name);
 #endif
   std::vector<std::string> GetAvailableDevices();
-  ov::Core& Get() {
-    return oe;
-  }
+  void SetCache(std::string cache_dir_path);
+  ov::Core& Get() {return oe;}
   void SetStreams(const std::string& device_type, int num_streams);
 };
 
@@ -61,8 +66,8 @@ class OVExeNetwork {
   ov::CompiledModel obj;
 
  public:
-  explicit OVExeNetwork(ov::CompiledModel md) { obj = md; }
-  OVExeNetwork() { obj = ov::CompiledModel(); }
+  explicit OVExeNetwork(ov::CompiledModel md): obj(md) {}
+  OVExeNetwork(): obj(ov::CompiledModel()) {}
   ov::CompiledModel& Get() { return obj; }
   OVInferRequest CreateInferRequest();
 };
@@ -77,8 +82,8 @@ class OVInferRequest {
   void Infer();
   void WaitRequest();
   void QueryStatus();
-  explicit OVInferRequest(ov::InferRequest obj) { ovInfReq = obj; }
-  OVInferRequest() { ovInfReq = ov::InferRequest(); }
+  explicit OVInferRequest(ov::InferRequest obj): ovInfReq(obj) {}
+  OVInferRequest(): ovInfReq(ov::InferRequest()) {}
   ov::InferRequest& GetNewObj() {
     return ovInfReq;
   }

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -122,6 +122,7 @@ std::vector<SupportedOp> supported_op_mode = {
     {"Dropout", V_2020_4, {"CPU", "GPU"}},
     {"Elu", V_2020_4, {"CPU", "GPU"}},
     {"Einsum", V_2023_1, {"CPU", "GPU"}},
+    {"EPContext", V_2024_0, {"CPU", "GPU", "NPU"}},
     {"Equal", V_2020_4, {"CPU", "GPU"}},
     {"Erf", V_2020_4, {"CPU", "GPU"}},
     {"Exp", V_2020_4, {"CPU", "GPU"}},

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1720,6 +1720,7 @@ ProviderOptions OrtOpenVINOProviderOptionsToOrtOpenVINOProviderOptionsV2(const O
 
   // Add new provider option below
   ov_options_converted_map["num_streams"] = "1";
+  ov_options_converted_map["export_ep_ctx_blob"] = "false";
   return ov_options_converted_map;
 }
 
@@ -1729,7 +1730,6 @@ std::shared_ptr<IExecutionProviderFactory> OpenVINOProviderFactoryCreator::Creat
 }
 
 std::shared_ptr<IExecutionProviderFactory> OpenVINOProviderFactoryCreator::Create(const ProviderOptions* provider_options_map) {
-  // std::cout << provider_options_map.at("num_streams") << std::endl;
   return s_library_openvino.Get().CreateExecutionProviderFactory(provider_options_map);
 }
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -966,6 +966,9 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
         } else if (option.first == "context") {
           OV_provider_options_map[option.first] = option.second;
           continue;
+        } else if (option.first == "export_ep_ctx_blob") {
+          OV_provider_options_map[option.first] = option.second;
+          continue;
         } else {
           ORT_THROW("Invalid OpenVINO EP option: ", option.first);
         }

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -304,6 +304,15 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
         } else {
           ov_options[key] = value;
         }
+      } else if (key == "export_ep_ctx_blob") {
+        if (value == "true" || value == "True" ||
+            value == "false" || value == "False") {
+          ov_options[key] = value;
+        } else {
+          ORT_THROW(
+              "[ERROR] [OpenVINO] The value for the key 'export_ep_ctx_blob' "
+              "should be a boolean i.e. true or false. Default value is false.\n");
+        }
       } else {
         ORT_THROW("[ERROR] [OpenVINO] wrong key type entered. Choose from the following runtime key options that are available for OpenVINO. ['device_type', 'device_id', 'enable_npu_fast_compile', 'num_of_threads', 'cache_dir', 'num_streams', 'enable_opencl_throttling', 'disable_dynamic_shapes'] \n");
       }


### PR DESCRIPTION
This PR adds a new provider option `export_ep_ctx_blob` to let OVEP export an 'optimized' onnx model with the compiled blob as one of the parameters of the EPContext contrib op of ORT.

- The resulting onnx has a name of the form `graph_name + "-ov_blob.onnx"`.
- This exported model can be used to infer on without any additional provider option.
- The exported model is invalid if it has more than one node.
- `cache_dir` parameter has no effect when working with an EPContext model.
- An exception is thrown when the openvino sdk version used to export the blob doesn't match the version of the current runtime. For example, if it's exported with 2023.3 but used with 2024.0, there will be an exception.