### PR TITLE
Add model_priority as a provider option

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -144,6 +144,10 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
     device_config.emplace(ov::enable_profiling(true));
   }
 #endif
+
+  // Set a priority level for the current workload for preemption;  default priority is "DEFAULT"
+  device_config.emplace(ov::hint::model_priority(global_context_.model_priority));
+
   if (global_context_.device_type.find("NPU") != std::string::npos) {
     std::pair<std::string, ov::Any> device_property;
     device_property = std::make_pair("NPU_COMPILER_TYPE", "DRIVER");

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -24,6 +24,7 @@ struct GlobalContext {
   std::string device_type;
   std::string precision_str;
   std::string cache_dir;
+  std::string model_priority = "DEFAULT";
   int num_streams;
   std::vector<bool> deviceAvailableList = {true, true, true, true, true, true, true, true};
   std::string onnx_model_name;

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -23,6 +23,7 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProv
   global_context_->precision_str = info.precision_;
   global_context_->enable_npu_fast_compile = info.enable_npu_fast_compile_;
   global_context_->cache_dir = info.cache_dir_;
+  global_context_->model_priority = info.model_priority_;
   global_context_->num_streams = info.num_streams_;
   global_context_->context = info.context_;
   global_context_->enable_opencl_throttling = info.enable_opencl_throttling_;

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -65,6 +65,7 @@ struct OpenVINOExecutionProviderInfo {
   bool enable_npu_fast_compile_;
   size_t num_of_threads_;
   std::string cache_dir_;
+  std::string model_priority_;
   int num_streams_;
   void* context_;
   bool enable_opencl_throttling_;
@@ -72,13 +73,14 @@ struct OpenVINOExecutionProviderInfo {
   bool export_ep_ctx_blob_;
 
   explicit OpenVINOExecutionProviderInfo(std::string dev_type, std::string precision, bool enable_npu_fast_compile,
-                                         size_t num_of_threads, std::string cache_dir, int num_streams,
-                                         void* context, bool enable_opencl_throttling,
+                                         size_t num_of_threads, std::string cache_dir, std::string model_priority,
+                                         int num_streams, void* context, bool enable_opencl_throttling, 
                                          bool disable_dynamic_shapes, bool export_ep_ctx_blob)
       : precision_(precision),
         enable_npu_fast_compile_(enable_npu_fast_compile),
         num_of_threads_(num_of_threads),
         cache_dir_(cache_dir),
+        model_priority_(model_priority),
         num_streams_(num_streams),
         context_(context),
         enable_opencl_throttling_(enable_opencl_throttling),
@@ -133,7 +135,7 @@ struct OpenVINOExecutionProviderInfo {
                        << "Choosing Device: " << device_type_ << " , Precision: " << precision_;
   }
   OpenVINOExecutionProviderInfo() {
-    OpenVINOExecutionProviderInfo("", "", false, 0, "", 1, NULL, false, false, false);
+    OpenVINOExecutionProviderInfo("", "", false, 0, "", "", 1, NULL, false, false, false);
   }
 };
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1692,6 +1692,7 @@ ProviderOptions OrtOpenVINOProviderOptionsToOrtOpenVINOProviderOptionsV2(const O
   // Add new provider option below
   ov_options_converted_map["num_streams"] = "1";
   ov_options_converted_map["export_ep_ctx_blob"] = "false";
+  ov_options_converted_map["model_priority"] = "DEFAULT";
   return ov_options_converted_map;
 }
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -957,6 +957,9 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
         } else if (option.first == "num_of_threads") {
           OV_provider_options_map[option.first] = option.second;
           continue;
+        } else if (option.first == "model_priority") {
+          OV_provider_options_map[option.first] = option.second;
+          continue;
         } else if (option.first == "num_streams") {
           OV_provider_options_map[option.first] = option.second;
           continue;

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -326,6 +326,8 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
         } else {
           ov_options[key] = value;
         }
+      } else if (key == "model_priority") {
+        ov_options[key] = value;
       } else if (key == "cache_dir") {
         ov_options[key] = value;
       } else if (key == "context") {


### PR DESCRIPTION
High-level OpenVINO model priority hint. Defines what model should be provided with more performant bounded resource first.

It's an optional parameter to provide a hint to the scheduler if a workload has higher or lower QoS needs.

Valid values are: LOW, MEDIUM, HIGH, DEFAULT

