### PR TITLE
Add custom blob generation for OV AUTO device

### DIFF
--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -13,7 +13,7 @@ ENV WORKDIR_PATH=/home/openvino
 WORKDIR $WORKDIR_PATH
 ENV DEBIAN_FRONTEND noninteractive
 
-ARG DEVICE=CPU_FP32
+ARG DEVICE=CPU
 ARG ONNXRUNTIME_REPO=https://github.com/microsoft/onnxruntime.git
 ARG ONNXRUNTIME_BRANCH=main
 

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -92,10 +92,10 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                                                            subgraph_context_.subgraph_name);
         ie_cnn_network_ = exe_network_.Get().get_runtime_model();
       } else if (!subgraph_context_.has_dynamic_input_shape &&
-                 global_context_.onnx_model_path_name != "" &&
-                 dev_prec != "CPU_FP16") {  // Inputs with static dimenstions
+                 global_context_.onnx_model_path_name.find(".onnx") != std::string ::npos) {  // Inputs with static dimenstions
         exe_network_ = global_context_.ie_core.CompileModel(global_context_.onnx_model_path_name,
                                                             hw_target,
+                                                            global_context_.cache_dir,
                                                             device_config,
                                                             subgraph_context_.subgraph_name);
         ie_cnn_network_ = exe_network_.Get().get_runtime_model();
@@ -170,7 +170,7 @@ void BasicBackend::EnableCaching() {
 
   if (!global_context_.cache_dir.empty()) {
     LOGS_DEFAULT(INFO) << log_tag << "Enables Caching";
-    global_context_.ie_core.SetCache(global_context_.cache_dir);
+    global_context_.ie_core.SetCache(global_context_.cache_dir, global_context_.device_type);
   }
 }
 

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -44,8 +44,9 @@ class OVCore {
                             std::string& hw_target,
                             ov::AnyMap& device_config,
                             std::string name);
-  OVExeNetwork CompileModel(const std::string model_path,
+  OVExeNetwork CompileModel(const std::string onnx_model_path,
                             std::string& hw_target,
+                            std::string cache_dir,
                             ov::AnyMap& device_config,
                             std::string name);
   OVExeNetwork ImportModel(std::istringstream& model_stream,
@@ -57,7 +58,7 @@ class OVCore {
   OVExeNetwork ImportModel(std::istringstream& model_stream, OVRemoteContextPtr context, std::string& name);
 #endif
   std::vector<std::string> GetAvailableDevices();
-  void SetCache(std::string cache_dir_path);
+  void SetCache(std::string cache_dir_path, std::string device_type);
   ov::Core& Get() { return oe; }
   void SetStreams(const std::string& device_type, int num_streams);
 };

--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -29,7 +29,8 @@ GetCapability::GetCapability(const GraphViewer& graph_viewer_param,
                              const std::string device_precision)
     : graph_viewer_(graph_viewer_param), device_type_(device_type_param), device_precision_(device_precision) {
   if (device_type_.find("NPU") != std::string::npos) {
-    device_type_ = "CPU_FP32";
+    device_type_ = "CPU";
+    device_precision_ = "FP32";
   }
 #if OPENVINO_VERSION_MAJOR == 2023 && OPENVINO_VERSION_MINOR == 1
   data_ops_ = new DataOps(graph_viewer_, V_2023_1, device_type_, device_precision_);

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -553,7 +553,7 @@
         "test_reduce_max_bool_inputs_cpu",
         "test_gelu_default_1_cpu", // Disabled due to accuracy mismatch
         "test_gelu_default_2_cpu"
-        
+
     ],
     "current_failing_tests_OPENVINO_NPU": [
         "^test_prelu_broadcast",

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -2617,7 +2617,7 @@ def main():
         raise BuildError("Using --get-api-doc requires a single build config")
 
     # Disabling unit tests for GPU on nuget creation
-    if args.use_openvino and args.use_openvino != "CPU_FP32" and args.build_nuget:
+    if args.use_openvino and args.use_openvino != "CPU" and args.build_nuget:
         args.test = False
 
     # GDK builds don't support testing

--- a/tools/ci_build/github/azure-pipelines/linux-openvino-ci-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/linux-openvino-ci-pipeline.yml
@@ -32,5 +32,5 @@ jobs:
   parameters:
     AgentPool : 'Linux-CPU-2019'
     JobName: 'Linux_CI_Dev'
-    RunDockerBuildArgs: '-o ubuntu20.04 -d openvino -v 2024.0.0 -x "--use_openvino CPU_FP32 --build_wheel"'
+    RunDockerBuildArgs: '-o ubuntu20.04 -d openvino -v 2024.0.0 -x "--use_openvino CPU --build_wheel"'
     TimeoutInMinutes: 120


### PR DESCRIPTION
### Description
Enable custom blob for AUTO device



### Motivation and Context
When user wants to use AUTO:GPU,CPU for faster FEIL, the blob will be generated only for GPU device.


