### PR TITLE
fix: Windows debug build patch for C2220 warning as error

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -8,6 +8,13 @@
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/openvino/backend_utils.h"
 
+#if defined(_MSC_VER)
+#pragma warning(disable : 4702) // Disable unreachable code warning
+#elif __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 using Exception = ov::Exception;
 
 namespace onnxruntime {


### PR DESCRIPTION
This PR fixes the Debug build issue on Windows while using MSVC compiler.

![image](https://github.com/intel/onnxruntime/assets/76202494/e01c2e2f-2044-4a27-933c-bd69ac531411)
