### PR TITLE
Update ReadMeOV for OV 2024.1, remove vulnerable package from Docker file

### DIFF
--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 #--------------------------------------------------------------------------
 
-ARG OPENVINO_VERSION=2024.0.0
+ARG OPENVINO_VERSION=2024.1.0
 
 
 # Build stage
@@ -34,7 +34,7 @@ RUN cat /etc/apt/sources.list | sed 's/^# deb-src/deb-src/g' > ./temp; mv temp /
 RUN apt update; apt install dpkg-dev
 RUN mkdir /sources
 WORKDIR /sources
-RUN apt-get source cron iso-codes lsb-release powermgmt-base python-apt-common python3-apt python3-dbus python3-gi unattended-upgrades libapt-pkg6.0 libhogweed5 libnettle7
+RUN apt-get source cron iso-codes lsb-release powermgmt-base python-apt-common python3-apt python3-dbus python3-gi libapt-pkg6.0 libhogweed5 libnettle7
 WORKDIR /
 RUN tar cvf GPL_sources.tar.gz /sources
 
@@ -46,8 +46,6 @@ USER root
 COPY --from=builder /home/openvino/onnxruntime/build/Linux/Release/dist/*.whl ./
 COPY --from=builder /GPL_sources.tar.gz ./
 RUN python3 -m pip install ./*.whl && rm ./*.whl
-RUN apt update; apt install -y unattended-upgrades && \
-    unattended-upgrade
 ARG BUILD_UID=1001
 ARG BUILD_USER=onnxruntimedev
 RUN adduser --uid $BUILD_UID $BUILD_USER

--- a/docs/python/ReadMeOV.rst
+++ b/docs/python/ReadMeOV.rst
@@ -14,7 +14,7 @@ Installation
 Requirements
 ^^^^^^^^^^^^
 
-- Ubuntu 18.04, 20.04, RHEL(CPU only) or Windows 10 - 64 bit
+- Ubuntu 18.04, 20.04, 22.04, RHEL(CPU only) or Windows 10 - 64 bit
 - Python 3.8 or 3.9 or 3.10 for Linux and only Python3.10 for Windows
 
 This package supports:
@@ -27,7 +27,7 @@ This package supports:
 Please install OpenVINO™ PyPi Package separately for Windows.
 For installation instructions on Windows please refer to  `OpenVINO™ Execution Provider for ONNX Runtime for Windows <https://github.com/intel/onnxruntime/releases/>`_.
 
-**OpenVINO™ Execution Provider for ONNX Runtime** Linux Wheels comes with pre-built libraries of OpenVINO™ version 2023.0.0 eliminating the need to install OpenVINO™ separately. The OpenVINO™ libraries are prebuilt with CXX11_ABI flag set to 0.
+**OpenVINO™ Execution Provider for ONNX Runtime** Linux Wheels comes with pre-built libraries of OpenVINO™ version 2024.1.0 eliminating the need to install OpenVINO™ separately.
 
 For more details on build and installation please refer to `Build <https://onnxruntime.ai/docs/build/eps.html#openvino>`_.
 


### PR DESCRIPTION
This pull request includes the following updates:

1. **ReadMeOV Update:**

- Updated the ReadMeOV.rst to mention support for OV 2024.1.

2. **Dockerfile Update:**

- Removed the unattended-upgrades library from the Dockerfile due to identified security vulnerabilities.

These changes ensure that the documentation is up to date with the latest version and new hardware support, and enhance the security of the Docker image by removing a vulnerable package.


