### PR TITLE
Add provider option for CPU fallback

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -105,7 +105,8 @@ BackendManager::BackendManager(const GlobalContext& global_context,
                                                       subgraph_context_,
                                                       ep_ctx_handle_);
     } catch (const OnnxRuntimeException& ex) {
-      if (device_type.find("NPU") != std::string::npos) {
+      if (device_type.find("NPU") != std::string::npos &&
+          GetGlobalContext().enable_npu_to_ov_cpu_fallback) {
         LOGS_DEFAULT(WARNING) << ex.what();
         LOGS_DEFAULT(WARNING) << "Model compilation failed at OV NPU."
                               << "Falling back to OV CPU for execution";
@@ -419,7 +420,8 @@ void BackendManager::Compute(OrtKernelContext* context) {
                                                       subgraph_context_,
                                                       ep_ctx_handle_);
       } catch (const OnnxRuntimeException& ex) {
-        if (GetGlobalContext().device_type.find("NPU") != std::string::npos) {
+        if (GetGlobalContext().device_type.find("NPU") != std::string::npos &&
+            GetGlobalContext().enable_npu_to_ov_cpu_fallback) {
           LOGS_DEFAULT(WARNING) << ex.what();
           LOGS_DEFAULT(WARNING) << "Model compilation failed at OV NPU."
                                 << "Falling back to OV CPU for execution";

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -21,6 +21,7 @@ struct GlobalContext {
   bool ep_context_embed_mode = true;
   bool export_ep_ctx_blob = false;
   bool enable_qdq_optimizer = false;
+  bool enable_npu_to_ov_cpu_fallback = false;
   size_t num_of_threads;
   std::string device_type;
   std::string precision_str;

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License
 #include <filesystem>
 #include <utility>
+#include <vector>
 
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/openvino/openvino_execution_provider.h"
@@ -33,6 +34,7 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProv
   global_context_->OpenVINO_Version = {OPENVINO_VERSION_MAJOR, OPENVINO_VERSION_MINOR};
   global_context_->export_ep_ctx_blob = info.export_ep_ctx_blob_;
   global_context_->enable_qdq_optimizer = info.enable_qdq_optimizer_;
+  global_context_->enable_npu_to_ov_cpu_fallback = info.enable_npu_to_ov_cpu_fallback_;
 
   // to check if target device is available
   // using ie_core capability GetAvailableDevices to fetch list of devices plugged in
@@ -60,6 +62,12 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const OpenVINOExecutionProv
             }
             if (info.device_type_.find("NPU") != std::string::npos) {
               device_found = true;
+              bool cpu_available = std::find(available_devices.begin(),
+                                             available_devices.end(),
+                                             "CPU")!= available_devices.end();
+              if(!cpu_available){
+                global_context_->enable_npu_to_ov_cpu_fallback = false;
+              }
               break;
             }
           }

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -74,6 +74,7 @@ struct OpenVINOExecutionProviderInfo {
   bool disable_dynamic_shapes_{false};
   bool export_ep_ctx_blob_{false};
   bool enable_qdq_optimizer_{false};
+  bool enable_npu_to_ov_cpu_fallback_{false};
 
   OpenVINOExecutionProviderInfo() = delete;
 
@@ -81,7 +82,7 @@ struct OpenVINOExecutionProviderInfo {
                                          size_t num_of_threads, std::string cache_dir, std::string model_priority,
                                          int num_streams, void* context, bool enable_opencl_throttling,
                                          bool disable_dynamic_shapes, bool export_ep_ctx_blob,
-                                         bool enable_qdq_optimizer)
+                                         bool enable_qdq_optimizer, bool enable_npu_to_ov_cpu_fallback)
       : precision_(precision),
         enable_npu_fast_compile_(enable_npu_fast_compile),
         num_of_threads_(num_of_threads),
@@ -92,7 +93,8 @@ struct OpenVINOExecutionProviderInfo {
         enable_opencl_throttling_(enable_opencl_throttling),
         disable_dynamic_shapes_(disable_dynamic_shapes),
         export_ep_ctx_blob_(export_ep_ctx_blob),
-        enable_qdq_optimizer_(enable_qdq_optimizer) {
+        enable_qdq_optimizer_(enable_qdq_optimizer),
+        enable_npu_to_ov_cpu_fallback_(enable_npu_to_ov_cpu_fallback) {
     std::set<std::string> ov_supported_device_types = {"CPU", "GPU",
                                                        "GPU.0", "GPU.1", "NPU"};
     if (dev_type == "") {

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -13,7 +13,8 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
                           const char* cache_dir, const char* model_priority,
                           int num_streams, void* context,
                           bool enable_opencl_throttling, bool disable_dynamic_shapes,
-                          bool export_ep_ctx_blob, bool enable_qdq_optimizer)
+                          bool export_ep_ctx_blob, bool enable_qdq_optimizer,
+                          bool enable_npu_to_ov_cpu_fallback)
       : precision_(precision),
         enable_npu_fast_compile_(enable_npu_fast_compile),
         num_of_threads_(num_of_threads),
@@ -23,7 +24,8 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
         enable_opencl_throttling_(enable_opencl_throttling),
         disable_dynamic_shapes_(disable_dynamic_shapes),
         export_ep_ctx_blob_(export_ep_ctx_blob),
-        enable_qdq_optimizer_(enable_qdq_optimizer) {
+        enable_qdq_optimizer_(enable_qdq_optimizer),
+        enable_npu_to_ov_cpu_fallback_(enable_npu_to_ov_cpu_fallback) {
     device_type_ = (device_type == nullptr) ? "" : device_type;
     cache_dir_ = (cache_dir == nullptr) ? "" : cache_dir;
   }
@@ -45,12 +47,14 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
   bool disable_dynamic_shapes_;
   bool export_ep_ctx_blob_;
   bool enable_qdq_optimizer_;
+  bool enable_npu_to_ov_cpu_fallback_;
 };
 
 std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {
   OpenVINOExecutionProviderInfo info(device_type_, precision_, enable_npu_fast_compile_, num_of_threads_,
                                      cache_dir_, model_priority_, num_streams_, context_, enable_opencl_throttling_,
-                                     disable_dynamic_shapes_, export_ep_ctx_blob_, enable_qdq_optimizer_);
+                                     disable_dynamic_shapes_, export_ep_ctx_blob_, enable_qdq_optimizer_,
+                                     enable_npu_to_ov_cpu_fallback_);
   return std::make_unique<OpenVINOExecutionProvider>(info);
 }
 
@@ -98,6 +102,8 @@ struct OpenVINO_Provider : Provider {
     void* context = nullptr;
 
     bool enable_qdq_optimizer = false;
+
+    bool enable_npu_to_ov_cpu_fallback = false;
 
     if (provider_options_map.find("device_type") != provider_options_map.end()) {
       device_type = provider_options_map.at("device_type").c_str();
@@ -256,6 +262,15 @@ struct OpenVINO_Provider : Provider {
         export_ep_ctx_blob = false;
       bool_flag = "";
     }
+
+    if (provider_options_map.find("enable_npu_to_ov_cpu_fallback") != provider_options_map.end()) {
+      bool_flag = provider_options_map.at("enable_npu_to_ov_cpu_fallback");
+      if (bool_flag == "true" || bool_flag == "True")
+        enable_npu_to_ov_cpu_fallback = true;
+      else if (bool_flag == "false" || bool_flag == "False")
+        enable_npu_to_ov_cpu_fallback = false;
+      bool_flag = "";
+    }
     return std::make_shared<OpenVINOProviderFactory>(const_cast<char*>(device_type.c_str()),
                                                      const_cast<char*>(precision.c_str()),
                                                      enable_npu_fast_compile,
@@ -267,7 +282,8 @@ struct OpenVINO_Provider : Provider {
                                                      enable_opencl_throttling,
                                                      disable_dynamic_shapes,
                                                      export_ep_ctx_blob,
-                                                     enable_qdq_optimizer);
+                                                     enable_qdq_optimizer,
+                                                     enable_npu_to_ov_cpu_fallback);
   }
 
   void Initialize() override {

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -58,13 +58,8 @@ std::shared_ptr<OVNetwork> OVCore::ReadModel(const std::string& model, const std
     ov::AnyVector params{&modelStream, model_path};
 
     FE = manager.load_by_model(params);
-    if (FE) {
-      inputModel = FE->load(params);
-      return FE->convert(inputModel);
-    } else {
-      ORT_THROW(log_tag + "[OpenVINO-EP] Unknown exception while Reading network");
-      return NULL;
-    }
+    inputModel = FE->load(params);
+    return FE->convert(inputModel);
   } catch (const Exception& e) {
     ORT_THROW(log_tag + "[OpenVINO-EP] Exception while Reading network: " + std::string(e.what()));
   } catch (...) {

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -358,8 +358,17 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
               "[ERROR] [OpenVINO] The value for the key 'export_ep_ctx_blob' "
               "should be a boolean i.e. true or false. Default value is false.\n");
         }
+      } else if (key == "enable_npu_to_ov_cpu_fallback") {
+        if (value == "true" || value == "True" ||
+            value == "false" || value == "False") {
+          ov_options[key] = value;
+        } else {
+          ORT_THROW(
+              "[ERROR] [OpenVINO] The value for the key 'enable_npu_to_ov_cpu_fallback' "
+              "should be a boolean i.e. true or false. Default value is false.\n");
+        }
       } else {
-        ORT_THROW("[ERROR] [OpenVINO] wrong key type entered. Choose from the following runtime key options that are available for OpenVINO. ['device_type', 'device_id', 'enable_npu_fast_compile', 'num_of_threads', 'cache_dir', 'num_streams', 'enable_opencl_throttling', 'disable_dynamic_shapes'] \n");
+        ORT_THROW("[ERROR] [OpenVINO] wrong key type entered. Choose from the following runtime key options that are available for OpenVINO. ['device_type', 'device_id', 'enable_npu_fast_compile', 'num_of_threads', 'cache_dir', 'num_streams', 'enable_opencl_throttling', 'disable_dynamic_shapes', 'enable_npu_to_ov_cpu_fallback'] \n");
       }
     }
     session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);


### PR DESCRIPTION
### Description
Add provider option to handle the fallback from OV NPU to OV CPU for compilation failures.


### Motivation and Context
This option provides the flexibility for user to opt for fallback incase of compilation failures on NPU. 
By default there is no fallback to OV CPU.

The PR also handles the build error for Windows Debug build.


