### PR TITLE
fix: Fixed the inference with Debug flags enabled for perf counters status logging

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -545,6 +545,8 @@ void BasicBackend::Infer(OrtKernelContext* ctx) {
       std::cout << "Inference successful" << std::endl;
     }
 
+    OVInferRequestPtr infer_request_ = infer_request;
+
     // Once the inference is completed, the infer_request becomes free and is placed back into pool of infer_requests_
     inferRequestsQueue_->putIdleRequest(std::move(infer_request));
 #ifndef NDEBUG
@@ -552,7 +554,7 @@ void BasicBackend::Infer(OrtKernelContext* ctx) {
     if (openvino_ep::backend_utils::IsDebugEnabled()) {
       inferRequestsQueue_->printstatus();  // Printing the elements of infer_requests_ vector pool only in debug mode
       std::string& hw_target = global_context_.device_type;
-      printPerformanceCounts(infer_request, std::cout, hw_target);
+      printPerformanceCounts(std::move(infer_request_), std::cout, hw_target);
     }
 #endif
 #endif


### PR DESCRIPTION
While using the DEBUG mode build flags viz. ORT_OPENVINO_ENABLE_DEBUG=1 and ORT_OPENVINO_ENABLE_CI_LOG=1, the onnxruntime_perf_test app inference seg faults after logging below -

.........
.........
Inference successful
printing elements of the vector (infer_requests_):
ovInfReq.query_state()

After which we must be getting performance benchmark statistics like performance counters and inference times.

To reproduce this issue, the user must build the project in DEBUG mode and use above flags before inference.

This PR fixes the issue.

