### PR TITLE
fix standalone dq conversion

### DIFF
--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -219,8 +219,8 @@ static bool DQFeedsASupportedOp(const Node* dq_node, const onnxruntime::GraphVie
       return true;
     }
   } else if (op_type == "Add") {
-    // Add => keeps all DQs 
-    return true
+    // Add => keeps all DQs
+    return true;
   }
   return false;
 }

--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -219,8 +219,8 @@ static bool DQFeedsASupportedOp(const Node* dq_node, const onnxruntime::GraphVie
       return true;
     }
   } else if (op_type == "Add") {
-    // Add keeps all DQs except if it has const inits
-    return !IsAnyDQAConstantInitializer(&target_node, src_graph);
+    // Add => keeps all DQs 
+    return true
   }
   return false;
 }


### PR DESCRIPTION
### Description
This PR allows the retention of Dequantize layer if it feeds as an input to the 'Add' (supported) operator.



### Motivation and Context
![image](https://github.com/intel/onnxruntime/assets/89963474/35005238-3420-43e6-99a2-b04954b314b0)
The stand alone dequantize layer after gather op was striped out and replaced by the Identity node.
The stand alone dequantize layer is having input as uint8 and output as float32 and this float32 output is input to the Add op.

Add op expects both inputs to be of same data type. When Identity op is inserted in place of dequantize layer the data type conversion has issues due to which the model PSQ1 is not functional. 

By retaining the Dequantize layer, we ensure proper data type conversion, allowing both inputs to the Add operator to be float32 and thus resolving the issue.


Open issues fixed with the PR:
https://jira.devtools.intel.com/browse/EISW-128302
https://jira.devtools.intel.com/browse/EISW-127924


