### PR TITLE
Correct value_info ordering to ensure deterministic graph proto serialization

### DIFF
--- a/onnxruntime/core/graph/graph_proto_serializer.cc
+++ b/onnxruntime/core/graph/graph_proto_serializer.cc
@@ -21,7 +21,21 @@ void GraphViewerToProto(const GraphViewer& graph_view,
     *(graph_proto.mutable_output()->Add()) = output_arg->ToProto();
   }
 
-  for (const auto* value_info : graph_view.GetValueInfo()) {
+  std::unordered_set<const onnxruntime::NodeArg *> value_info_ = graph_view.GetValueInfo();
+
+  // Reserve memory for the vector to avoid reallocations
+  std::vector<const NodeArg*> value_info_sorted;
+  value_info_sorted.reserve(value_info_.size());
+
+  value_info_sorted.assign(value_info_.begin(), value_info_.end());
+  auto sort_predicate = [](const NodeArg* v1, const NodeArg* v2) {
+    return v1->Name() < v2->Name();
+  };
+
+  // This ensures consistent ordering of value_info entries in the output graph
+  std::sort(value_info_sorted.begin(), value_info_sorted.end(), sort_predicate);
+
+  for (const auto* value_info : value_info_sorted) {
     *(graph_proto.mutable_value_info()->Add()) = value_info->ToProto();
   }
 


### PR DESCRIPTION
Ensure deterministic ordering of value_info in graph proto serialization by sorting NodeArgs lexicographically by name


