### PR TITLE
ACCURACY mode is for both Auto:GPU, CPU and GPU

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -140,8 +140,7 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
   if (global_context_.precision_str.find("FP32") != std::string::npos) {
     device_config.emplace(ov::hint::inference_precision("f32"));
   }
-  if (global_context_.precision_str.find("ACCURACY") != std::string::npos &&
-      global_context_.device_type == "GPU") {
+  if (global_context_.precision_str.find("ACCURACY") != std::string::npos) {
     if (global_context_.OpenVINO_Version.at(0) >= 2024 && global_context_.OpenVINO_Version.at(1) >= 1) {
       device_config.emplace(ov::hint::inference_precision(ov::element::undefined));
       device_config.emplace(ov::hint::execution_mode(ov::hint::ExecutionMode::ACCURACY));


### PR DESCRIPTION
### Description
execution_mode::Accuracy must be set to all types. 


### Motivation and Context
This change is required because execution:mode to Accuracy can be set for all devices. 
- If it fixes an open issue, please link to the issue here. -->


