### PR TITLE
Updated fix for setting precision with Auto Plugin

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -37,7 +37,7 @@ class BasicBackend : public IBackend {
   void PopulateCompiledDirectory(std::string, std::string&, std::string&, bool&);
   bool ValidateSubgraph(std::map<std::string, std::shared_ptr<ov::Node>>& const_outputs_map);
   void PopulateConfigValue(ov::AnyMap& device_config);
-  void EnableCaching();
+  void EnableCaching(ov::AnyMap& device_config);
   void EnableGPUThrottling(ov::AnyMap& device_config);
   void EnableStreams();
   void SetNumThreads(ov::AnyMap& device_config);

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -72,7 +72,7 @@ std::shared_ptr<OVNetwork> OVCore::ReadModel(const std::string& model, const std
 OVExeNetwork OVCore::CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
                                   std::string& hw_target,
                                   ov::AnyMap& device_config,
-                                  std::string name) {
+                                  const std::string& name) {
   ov::CompiledModel obj;
   try {
     obj = oe.compile_model(ie_cnn_network, hw_target, device_config);
@@ -88,23 +88,13 @@ OVExeNetwork OVCore::CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_netwo
   }
 }
 
-OVExeNetwork OVCore::CompileModel(const std::string onnx_model_path,
+OVExeNetwork OVCore::CompileModel(const std::string& onnx_model_path,
                                   std::string& hw_target,
-                                  std::string precision,
-                                  std::string cache_dir,
                                   ov::AnyMap& device_config,
-                                  std::string name) {
+                                  const std::string& name) {
   ov::CompiledModel obj;
   try {
-    if (hw_target == "AUTO:GPU,CPU") {
-      obj = oe.compile_model(onnx_model_path,
-                             "AUTO",
-                             ov::device::priorities("GPU", "CPU"),
-                             ov::device::properties("GPU", {ov::cache_dir(cache_dir),
-                                                            ov::hint::inference_precision(precision)}));
-    } else {
-      obj = oe.compile_model(onnx_model_path, hw_target, device_config);
-    }
+    obj = oe.compile_model(onnx_model_path, hw_target, device_config);
 #ifndef NDEBUG
     printDebugInfo(obj);
 #endif
@@ -120,7 +110,7 @@ OVExeNetwork OVCore::CompileModel(const std::string onnx_model_path,
 OVExeNetwork OVCore::ImportModel(std::shared_ptr<std::istringstream> model_stream,
                                  std::string& hw_target,
                                  ov::AnyMap& device_config,
-                                 std::string name) {
+                                 const std::string& name) {
   try {
     auto obj = oe.import_model(*model_stream, hw_target, device_config);
 #ifndef NDEBUG
@@ -135,10 +125,8 @@ OVExeNetwork OVCore::ImportModel(std::shared_ptr<std::istringstream> model_strea
   }
 }
 
-void OVCore::SetCache(std::string cache_dir_path, std::string device_type) {
-  if (device_type != "AUTO:GPU,CPU") {
-    oe.set_property(ov::cache_dir(cache_dir_path));
-  }
+void OVCore::SetCache(const std::string& cache_dir_path) {
+     oe.set_property(ov::cache_dir(cache_dir_path));
 }
 
 #ifdef IO_BUFFER_ENABLED

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -39,27 +39,29 @@ class OVCore {
   ov::Core oe;
 
  public:
+  //OV Interface For Reading Model
   std::shared_ptr<OVNetwork> ReadModel(const std::string& model_stream, const std::string& model_path) const;
+  //OV Interface for Compiling OV Model Type
   OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
                             std::string& hw_target,
                             ov::AnyMap& device_config,
-                            std::string name);
-  OVExeNetwork CompileModel(const std::string onnx_model_path,
+                            const std::string& name);
+  //OV Interface for Fast Compile
+  OVExeNetwork CompileModel(const std::string& onnx_model_path,
                             std::string& hw_target,
-                            std::string precision,
-                            std::string cache_dir,
                             ov::AnyMap& device_config,
-                            std::string name);
+                            const std::string& name);
+  //OV Interface for Import model Stream
   OVExeNetwork ImportModel(std::shared_ptr<std::istringstream> model_stream,
                            std::string& hw_target,
                            ov::AnyMap& device_config,
-                           std::string name);
+                           const std::string& name);
 #ifdef IO_BUFFER_ENABLED
   OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& model, OVRemoteContextPtr context, std::string& name);
   OVExeNetwork ImportModel(std::shared_ptr<std::istringstream> model_stream, OVRemoteContextPtr context, std::string& name);
 #endif
   std::vector<std::string> GetAvailableDevices();
-  void SetCache(std::string cache_dir_path, std::string device_type);
+  void SetCache(const std::string& cache_dir_path);
   ov::Core& Get() { return oe; }
   void SetStreams(const std::string& device_type, int num_streams);
 };

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -39,19 +39,19 @@ class OVCore {
   ov::Core oe;
 
  public:
-  //OV Interface For Reading Model
+  // OV Interface For Reading Model
   std::shared_ptr<OVNetwork> ReadModel(const std::string& model_stream, const std::string& model_path) const;
-  //OV Interface for Compiling OV Model Type
+  // OV Interface for Compiling OV Model Type
   OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
                             std::string& hw_target,
                             ov::AnyMap& device_config,
                             const std::string& name);
-  //OV Interface for Fast Compile
+  // OV Interface for Fast Compile
   OVExeNetwork CompileModel(const std::string& onnx_model_path,
                             std::string& hw_target,
                             ov::AnyMap& device_config,
                             const std::string& name);
-  //OV Interface for Import model Stream
+  // OV Interface for Import model Stream
   OVExeNetwork ImportModel(std::shared_ptr<std::istringstream> model_stream,
                            std::string& hw_target,
                            ov::AnyMap& device_config,


### PR DESCRIPTION
### Description
Precision Accuracy is being set for AUTO as well
Cache dir is being set for ov::Model Type (Compile Model Function)
Fast Compile with Model Path is only being used for GPU currently. 

### Motivation and Context
The bug fix contains fix for 
CVS-142074 | [Adobe][AUTO] Corruption with Adobe InPainting when run with Accuracy precision | Caused by CVS-146476
CVS-146476 | ONNX option precision=ACCRUACY doesn't pass to OV Runtime | Fixing in ONNX OV EP
CVS-146816 | [ONNX] option cache_dir doesn't pass to OV Runtime | Impact the model cache. Fixing in ONNX EP.
.