### PR TITLE
fix coverity issues for lnl-dev branch

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -154,7 +154,7 @@ Status BackendManager::ExportCompiledBlobAsEPCtxNode(const onnxruntime::GraphVie
   else
     graph_name = global_context_.onnx_model_path_name;
   // Remove extension so we can append suffix to form the complete name of output graph
-  graph_name = [&]() {
+  graph_name = [&]() -> const std::string{
     size_t dot = graph_name.find_last_of(".");
     if (dot == std::string::npos) return graph_name;
     return graph_name.substr(0, dot);
@@ -254,7 +254,7 @@ static void DumpOpenVINOEPModel(std::string onnx_model_path_name,
                                 ONNX_NAMESPACE::ModelProto* model_proto,
                                 const onnxruntime::Node& fused_node) {
   if (openvino_ep::backend_utils::IsDebugEnabled()) {
-    auto model_name = onnx_model_path_name.empty() ? "unknown.onnx" : onnx_model_path_name;
+    auto model_name = onnx_model_path_name.empty() ? "unknown.onnx" : std::move(onnx_model_path_name) ;
 #ifdef _WIN32
     size_t slash = model_name.find_last_of("\\");
 #else

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -99,7 +99,7 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
         const std::string model = model_proto.SerializeAsString();
         exe_network_ = global_context_.ie_core.CompileModel(model,
                                                             hw_target,
-                                                            prec_str,
+                                                            std::move(prec_str),
                                                             global_context_.cache_dir,
                                                             device_config,
                                                             subgraph_context_.subgraph_name);
@@ -276,7 +276,7 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
         }
 
         try {
-          infer_request->SetTensor(input_name, tensor_ptr);
+          infer_request->SetTensor(std::move(input_name), tensor_ptr);
         } catch (const char* msg) {
           ORT_THROW(msg);
         }

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -85,11 +85,11 @@ struct OpenVINOExecutionProviderInfo {
                                          bool disable_dynamic_shapes, bool export_ep_ctx_blob,
                                          bool enable_qdq_optimizer, bool disable_cpu_fallback,
                                          bool so_epctx_embed_mode)
-      : precision_(precision),
+      : precision_(std::move(precision)),
         enable_npu_fast_compile_(enable_npu_fast_compile),
         num_of_threads_(num_of_threads),
         cache_dir_(std::move(cache_dir)),
-        model_priority_(model_priority),
+        model_priority_(std::move(model_priority)),
         num_streams_(num_streams),
         context_(context),
         enable_opencl_throttling_(enable_opencl_throttling),
@@ -131,7 +131,7 @@ struct OpenVINOExecutionProviderInfo {
       device_type_ = std::move(dev_type);
     } else if (dev_type.find("HETERO") == 0 || dev_type.find("MULTI") == 0 || dev_type.find("AUTO") == 0) {
       std::vector<std::string> devices = parseDevices(dev_type);
-      device_type_ = dev_type;
+      device_type_ = std::move(dev_type);
     } else {
       ORT_THROW("Invalid device string: " + dev_type);
     }


### PR DESCRIPTION
### Description

This PR fixes coverity issues for ovep-develop-lnl-1.1 branch


### Motivation and Context
Issues are attached in the excel file

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/kalesaur/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/kalesaur/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:"Short Date";}
.xl66
	{color:#006100;
	background:#C6EFCE;
	mso-pattern:black none;}
.xl67
	{color:#006100;
	mso-number-format:"Short Date";
	background:#C6EFCE;
	mso-pattern:black none;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">


CID | Type | Impact | Status | First Detected | Owner | Classification | Severity | Action | Component | Category | File | Function
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1586124 | Use of auto that causes a copy | Low | New | 4/29/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/backend_manager.cc | operator ()
1576730 | COPY_INSTEAD_OF_MOVE | Low | New | 1/31/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/backends/basic_backend.cc | StartAsyncInference
1598199 | COPY_INSTEAD_OF_MOVE | Low | New | 7/17/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/openvino_execution_provider.h | OpenVINOExecutionProviderInfo
1598182 | COPY_INSTEAD_OF_MOVE | Low | New | 7/17/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/openvino_execution_provider.h | OpenVINOExecutionProviderInfo
1598139 | COPY_INSTEAD_OF_MOVE | Low | New | 7/17/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/openvino_execution_provider.h | OpenVINOExecutionProviderInfo
1587886 | COPY_INSTEAD_OF_MOVE | Low | New | 5/14/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/backend_manager.cc | DumpOpenVINOEPModel
1598197 | Use of auto that causes a copy | Low | New | 7/17/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc | DQFeedsASupportedOp
1565307 | COPY_INSTEAD_OF_MOVE | Low | New | 6/15/2023 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/openvino_execution_provider.cc | Compile
1598210 | COPY_INSTEAD_OF_MOVE | Low | New | 7/17/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc | CheckQRuleSet
1587887 | Use of auto that causes a copy | Low | New | 5/14/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc | CheckQRuleSet
1598208 | Use of auto that causes a copy | Low | New | 7/17/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc | CheckQFeedsIntoQuantizedOutput
1587885 | Use of auto that causes a copy | Low | New | 5/14/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc | CheckDQRuleSet
1587834 | COPY_INSTEAD_OF_MOVE | Low | New | 5/13/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/backends/basic_backend.cc | BasicBackend
1587882 | Use of auto that causes a copy | Low | New | 5/14/2024 | Unassigned | Unclassified | Unspecified | Undecided | ONNX Runtime | Performance inefficiencies | /onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc | AddQDQNodeUnit



</body>

</html>






































































