### PR TITLE
Validate numeric input for number of threads

### DIFF
--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -184,6 +184,10 @@ struct OpenVINO_Provider : Provider {
     }
 
     if (provider_options_map.find("num_of_threads") != provider_options_map.end()) {
+      if (!std::all_of(provider_options_map.at("num_of_threads").begin(),
+                 provider_options_map.at("num_of_threads").end(), ::isdigit)) {
+        ORT_THROW("[ERROR] [OpenVINO-EP] Number of threads should be a number. \n");
+      }
       num_of_threads = std::stoi(provider_options_map.at("num_of_threads"));
       if (num_of_threads <= 0) {
         num_of_threads = 1;


### PR DESCRIPTION
1. Add check to ensure input for 'num_of_threads' is a valid numeric string
2. Prevent conversion of non-numeric strings (e.g., '1b', '1#c') to integers
3. Throw exception for invalid inputs to improve error handling


