### PR TITLE
Validate numeric input for number of threads and Updated the docker script for ubuntu 22

### DIFF
--- a/dockerfiles/Dockerfile.openvino
+++ b/dockerfiles/Dockerfile.openvino
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: MIT
 #--------------------------------------------------------------------------
 
-ARG OPENVINO_VERSION=2024.0.0
+ARG OPENVINO_VERSION=2024.2.0
 
 
 # Build stage
-FROM openvino/ubuntu20_runtime:${OPENVINO_VERSION} AS builder
+FROM openvino/ubuntu22_runtime:${OPENVINO_VERSION} AS builder
 
 ENV WORKDIR_PATH=/home/openvino
 WORKDIR $WORKDIR_PATH
@@ -34,20 +34,18 @@ RUN cat /etc/apt/sources.list | sed 's/^# deb-src/deb-src/g' > ./temp; mv temp /
 RUN apt update; apt install dpkg-dev
 RUN mkdir /sources
 WORKDIR /sources
-RUN apt-get source cron iso-codes lsb-release powermgmt-base python-apt-common python3-apt python3-dbus python3-gi unattended-upgrades libapt-pkg6.0 libhogweed5 libnettle7
+RUN apt-get source cron iso-codes lsb-release powermgmt-base python-apt-common python3-apt python3-dbus python3-gi libapt-pkg6.0 libhogweed6 libnettle8
 WORKDIR /
 RUN tar cvf GPL_sources.tar.gz /sources
 
 # Deploy stage
-FROM openvino/ubuntu20_runtime:${OPENVINO_VERSION}
+FROM openvino/ubuntu22_runtime:${OPENVINO_VERSION}
 
 ENV DEBIAN_FRONTEND noninteractive
 USER root
 COPY --from=builder /home/openvino/onnxruntime/build/Linux/Release/dist/*.whl ./
 COPY --from=builder /GPL_sources.tar.gz ./
 RUN python3 -m pip install ./*.whl && rm ./*.whl
-RUN apt update; apt install -y unattended-upgrades && \
-    unattended-upgrade
 ARG BUILD_UID=1001
 ARG BUILD_USER=onnxruntimedev
 RUN adduser --uid $BUILD_UID $BUILD_USER

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -192,6 +192,10 @@ struct OpenVINO_Provider : Provider {
     }
 
     if (provider_options_map.find("num_of_threads") != provider_options_map.end()) {
+      if (!std::all_of(provider_options_map.at("num_of_threads").begin(),
+                 provider_options_map.at("num_of_threads").end(), ::isdigit)) {
+        ORT_THROW("[ERROR] [OpenVINO-EP] Number of threads should be a number. \n");
+      }
       num_of_threads = std::stoi(provider_options_map.at("num_of_threads"));
       if (num_of_threads <= 0) {
         num_of_threads = 1;

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -193,7 +193,7 @@ struct OpenVINO_Provider : Provider {
 
     if (provider_options_map.find("num_of_threads") != provider_options_map.end()) {
       if (!std::all_of(provider_options_map.at("num_of_threads").begin(),
-                 provider_options_map.at("num_of_threads").end(), ::isdigit)) {
+                       provider_options_map.at("num_of_threads").end(), ::isdigit)) {
         ORT_THROW("[ERROR] [OpenVINO-EP] Number of threads should be a number. \n");
       }
       num_of_threads = std::stoi(provider_options_map.at("num_of_threads"));
@@ -311,7 +311,7 @@ struct OpenVINO_Provider : Provider {
           auto parent_path = file_path.parent_path();
           if (!std::filesystem::is_directory(parent_path) &&
               !std::filesystem::create_directory(parent_path)) {
-            ORT_THROW("[ERROR] [OpenVINO] Failed to create directory : " +file_path.parent_path().generic_string()+ " \n");
+            ORT_THROW("[ERROR] [OpenVINO] Failed to create directory : " + file_path.parent_path().generic_string() + " \n");
           }
           cache_dir = ep_context_file_path_.c_str();
         } else {


### PR DESCRIPTION
1. Add check to ensure input for 'num_of_threads' is a valid numeric string
2. Prevent conversion of non-numeric strings (e.g., '1b', '1#c') to integers
3. Throw exception for invalid inputs to improve error handling
4. Updated the docker script for ubuntu 22

