### PR TITLE
fix handling of multiple QuantizeLinear nodes

### DIFF
--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -583,22 +583,23 @@ static void AddQDQNodeUnit(onnxruntime::Graph& dst_graph,
 
   // Handle Qs in the NodeUnit
   if (!node_unit.GetQNodes().empty()) {
-    ORT_ENFORCE(node_unit.GetQNodes().size() == 1);
-    const auto& q_node = node_unit.GetQNodes().at(0);
+    for (auto i = 0 ; i < node_unit.GetQNodes().size() ; i++) {
+      const auto& q_node = node_unit.GetQNodes().at(0);
 
-    SkipReason reason;
+      SkipReason reason;
 
-    bool keep_q = CheckQRuleSet(node_unit, q_node, src_graph, reason);
+      bool keep_q = CheckQRuleSet(node_unit, q_node, src_graph, reason);
 
-    if (keep_q) {
-      AddNode(initializers_to_keep, src_graph, dst_graph, *q_node);
-      // if keep_q, then output defs of the target node doesn't change
-      output_args.push_back(&dst_graph.GetOrCreateNodeArg(target_node.OutputDefs().at(0)->Name(),
-                                                          target_node.OutputDefs().at(0)->TypeAsProto()));
-    } else {
-      // convert this Q to float
-      output_args.push_back(&ProcessNodeUnitIO(dst_graph, src_graph, initializers_to_keep,
-                                               node_unit_outputs.at(0)));
+      if (keep_q) {
+        AddNode(initializers_to_keep, src_graph, dst_graph, *q_node);
+        // if keep_q, then output defs of the target node doesn't change
+        output_args.push_back(&dst_graph.GetOrCreateNodeArg(target_node.OutputDefs().at(i)->Name(),
+                                                            target_node.OutputDefs().at(i)->TypeAsProto()));
+      } else {
+        // convert this Q to float
+        output_args.push_back(&ProcessNodeUnitIO(dst_graph, src_graph, initializers_to_keep,
+                                                node_unit_outputs.at(i)));
+      }
     }
   } else {
     for (const auto& node_unit_output : node_unit_outputs) {


### PR DESCRIPTION
### Description
This fix addresses the issue of handling multiple QLinear nodes as outputs from the target node in OVEP. Previously, the stripping logic only supported a single Q node, leading to incorrect stripping of additional Q nodes.



### Motivation and Context
The OVEP stripping logic was limited to handling a single Q node as an output from the target node. As a result, additional Q nodes were being stripped, despite the stripping rules indicating they should be retained.

With this fix, OVEP can now properly handle multiple Q nodes according to the specified stripping rules, ensuring that the fate of each Q node is correctly determined.


