### PR TITLE
fix debug build

### DIFF
--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -583,7 +583,7 @@ static void AddQDQNodeUnit(onnxruntime::Graph& dst_graph,
 
   // Handle Qs in the NodeUnit
   if (!node_unit.GetQNodes().empty()) {
-    for (auto i = 0 ; i < node_unit.GetQNodes().size() ; i++) {
+    for (size_t i = 0 ; i < node_unit.GetQNodes().size() ; i++) {
       const auto& q_node = node_unit.GetQNodes().at(i);
 
       SkipReason reason;

--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -584,7 +584,7 @@ static void AddQDQNodeUnit(onnxruntime::Graph& dst_graph,
   // Handle Qs in the NodeUnit
   if (!node_unit.GetQNodes().empty()) {
     for (auto i = 0 ; i < node_unit.GetQNodes().size() ; i++) {
-      const auto& q_node = node_unit.GetQNodes().at(0);
+      const auto& q_node = node_unit.GetQNodes().at(i);
 
       SkipReason reason;
 


### PR DESCRIPTION
### Description
This pull request resolves issues with the debug build where the compiler treated warnings as errors. 



### Motivation and Context
This PR  addresses the -Wsign-compare warning, which occurs when comparing signed and unsigned integers. Such comparisons can lead to unexpected behavior and need to be corrected. 
It also addresses small issue in handling multiple q-nodes.


