### PR TITLE
update: Setup EpCtx Graph Resolve for Debug only

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.h
+++ b/onnxruntime/core/providers/openvino/backend_utils.h
@@ -29,6 +29,8 @@ namespace openvino_ep {
 namespace backend_utils {
 const std::string log_tag = "[OpenVINO-EP] ";
 
+std::unique_ptr<ONNX_NAMESPACE::ModelProto> ExternalWeightsModel(const std::string& model_path, ONNX_NAMESPACE::ModelProto&& model_proto);
+
 bool IsDebugEnabled();
 
 // Internal diagnostic function.

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -94,7 +94,9 @@ BasicBackend::BasicBackend(const ONNX_NAMESPACE::ModelProto& model_proto,
                  hw_target.find("NPU") != std::string::npos) {
         std::shared_ptr<ov::Model> ov_model;
         {
-          const std::string model = model_proto.SerializeAsString();
+          auto dnn_proto = ExternalWeightsModel(global_context_.onnx_model_path_name, std::move(model_proto));
+          const std::string model = dnn_proto.SerializeAsString();
+          // const std::string model = model_proto.SerializeAsString();
           ov_model = global_context_.ie_core.Get().read_model(model, ov::Tensor());
         }
         exe_network_ = OVExeNetwork(global_context_.ie_core.Get().compile_model(ov_model, hw_target, device_config));

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
@@ -71,7 +71,10 @@ Status EPCtxHandler::ExportEPCtxModel(const GraphViewer& graph_viewer,
   }
   // Create EP context node
   graph_build.AddNode(graph_name, EPCONTEXT_OP, "", inputs, outputs, std::move(*node_attributes), kMSDomain);
+
+#ifndef NDEBUG
   ORT_ENFORCE(graph_build.Resolve().IsOK());
+#endif
 
   {
     // Serialize modelproto to string


### PR DESCRIPTION
### Description
This PR amends the EPCtx graph validation for Debug only build. As the Resolve additionally calls ToProto() which makes additional copies of the target graph attributes internally.

Upcoming changes will be raised in a separate/ same PR to manage the ToProto() copy creation for EPCtx

