### PR TITLE
Implements blob compatibility check for NPU

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -111,7 +111,8 @@ BackendManager::BackendManager(const GlobalContext& global_context,
       ORT_THROW(ex.what());
 #else
       if (device_type.find("NPU") != std::string::npos &&
-          !GetGlobalContext().disable_cpu_fallback) {
+          !GetGlobalContext().disable_cpu_fallback &&
+          !ep_ctx_handle_.IsValidOVEPCtxGraph()) {
         LOGS_DEFAULT(WARNING) << ex.what();
         LOGS_DEFAULT(WARNING) << "Model compilation failed at OV NPU."
                               << "Falling back to OV CPU for execution";

--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -75,24 +75,24 @@ BackendManager::BackendManager(const GlobalContext& global_context,
                 "QDQ stripping should not be enabled for models with dynamic input shapes. "
                 "Set enable_qdq_optimizer to False");
     if ((GetGlobalContext().device_type.find("CPU") != std::string::npos ||
-        GetGlobalContext().device_type.find("GPU") != std::string::npos) &&
+         GetGlobalContext().device_type.find("GPU") != std::string::npos) &&
         !GetGlobalContext().disable_dynamic_shapes) {
-        LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Starting backend initialization. "
-                           << "Creating backend Dynamic Shapes";
-        try {
-          concrete_backend_ = BackendFactory::MakeBackend(model_proto,
-                                                          GetGlobalContext(),
-                                                          subgraph_context_,
-                                                          ep_ctx_handle_);
-        } catch (std::string const& msg) {
-          ORT_THROW(msg);
-        }
-        LOGS_DEFAULT(INFO) << "[OpenVINO-EP] "
-                           << "Backend created for graph " << subgraph_context_.subgraph_name;
+      LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Starting backend initialization. "
+                         << "Creating backend Dynamic Shapes";
+      try {
+        concrete_backend_ = BackendFactory::MakeBackend(model_proto,
+                                                        GetGlobalContext(),
+                                                        subgraph_context_,
+                                                        ep_ctx_handle_);
+      } catch (std::string const& msg) {
+        ORT_THROW(msg);
+      }
+      LOGS_DEFAULT(INFO) << "[OpenVINO-EP] "
+                         << "Backend created for graph " << subgraph_context_.subgraph_name;
     } else {
-        // Only cache model_proto in global to rewrite the model with input shapes at runtime.
-        // For dynamic backend creation
-        model_proto_ = std::move(model_proto);
+      // Only cache model_proto in global to rewrite the model with input shapes at runtime.
+      // For dynamic backend creation
+      model_proto_ = std::move(model_proto);
     }
   } else {
     LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has concrete input dims. "

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -139,42 +139,50 @@ common::Status OpenVINOExecutionProvider::Compile(
     // During backend creation, we check if user wants to use precompiled blob onnx model or the original model
     // For precompiled blob, directly load the model instead of compiling the model
     // For original model, check if the user wants to export a model with pre-compiled blob
+    try {
+      std::shared_ptr<openvino_ep::BackendManager> backend_manager =
+          std::make_shared<openvino_ep::BackendManager>(*global_context_,
+                                                        fused_node,
+                                                        graph_body_viewer,
+                                                        *GetLogger(),
+                                                        ep_ctx_handle_);
+      compute_info.create_state_func =
+          [backend_manager](ComputeContext* context, FunctionState* state) {
+            OpenVINOEPFunctionState* p = new OpenVINOEPFunctionState();
+            p->allocate_func = context->allocate_func;
+            p->destroy_func = context->release_func;
+            p->allocator_handle = context->allocator_handle;
+            p->backend_manager = backend_manager;
+            *state = static_cast<FunctionState>(p);
+            return 0;
+          };
+      compute_info.compute_func = [](FunctionState state, const OrtApi* /* api */, OrtKernelContext* context) {
+        auto function_state = static_cast<OpenVINOEPFunctionState*>(state);
+        try {
+          function_state->backend_manager->Compute(context);
+        } catch (const std::exception& ex) {
+          return common::Status(common::ONNXRUNTIME, common::FAIL, ex.what());
+        }
+        return Status::OK();
+      };
 
-    std::shared_ptr<openvino_ep::BackendManager> backend_manager =
-        std::make_shared<openvino_ep::BackendManager>(*global_context_,
-                                                      fused_node,
-                                                      graph_body_viewer,
-                                                      *GetLogger(),
-                                                      ep_ctx_handle_);
-
-    compute_info.create_state_func =
-        [backend_manager](ComputeContext* context, FunctionState* state) {
-          OpenVINOEPFunctionState* p = new OpenVINOEPFunctionState();
-          p->allocate_func = context->allocate_func;
-          p->destroy_func = context->release_func;
-          p->allocator_handle = context->allocator_handle;
-          p->backend_manager = backend_manager;
-          *state = static_cast<FunctionState>(p);
-          return 0;
-        };
-    compute_info.compute_func = [](FunctionState state, const OrtApi* /* api */, OrtKernelContext* context) {
-      auto function_state = static_cast<OpenVINOEPFunctionState*>(state);
-      try {
-        function_state->backend_manager->Compute(context);
-      } catch (const std::exception& ex) {
-        return common::Status(common::ONNXRUNTIME, common::FAIL, ex.what());
+      compute_info.release_state_func =
+          [](FunctionState state) {
+            if (state) {
+              OpenVINOEPFunctionState* function_state = static_cast<OpenVINOEPFunctionState*>(state);
+              delete function_state;
+            }
+          };
+      node_compute_funcs.push_back(compute_info);
+    } catch (const OnnxRuntimeException& ex) {
+      std::string exception_str = ex.what();
+      if (exception_str.find("ZE_RESULT_ERROR_UNKNOWN") != std::string::npos ||
+          exception_str.find("ZE_RESULT_ERROR_UNINITIALIZED") != std::string::npos) {
+        return Status(common::ONNXRUNTIME, common::EP_FAIL, "Model needs to be recompiled");
+      } else {
+        ORT_THROW(exception_str);
       }
-      return Status::OK();
-    };
-
-    compute_info.release_state_func =
-        [](FunctionState state) {
-          if (state) {
-            OpenVINOEPFunctionState* function_state = static_cast<OpenVINOEPFunctionState*>(state);
-            delete function_state;
-          }
-        };
-    node_compute_funcs.push_back(compute_info);
+    }
   }
 
   return Status::OK();

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -139,50 +139,42 @@ common::Status OpenVINOExecutionProvider::Compile(
     // During backend creation, we check if user wants to use precompiled blob onnx model or the original model
     // For precompiled blob, directly load the model instead of compiling the model
     // For original model, check if the user wants to export a model with pre-compiled blob
-    try {
-      std::shared_ptr<openvino_ep::BackendManager> backend_manager =
-          std::make_shared<openvino_ep::BackendManager>(*global_context_,
-                                                        fused_node,
-                                                        graph_body_viewer,
-                                                        *GetLogger(),
-                                                        ep_ctx_handle_);
-      compute_info.create_state_func =
-          [backend_manager](ComputeContext* context, FunctionState* state) {
-            OpenVINOEPFunctionState* p = new OpenVINOEPFunctionState();
-            p->allocate_func = context->allocate_func;
-            p->destroy_func = context->release_func;
-            p->allocator_handle = context->allocator_handle;
-            p->backend_manager = backend_manager;
-            *state = static_cast<FunctionState>(p);
-            return 0;
-          };
-      compute_info.compute_func = [](FunctionState state, const OrtApi* /* api */, OrtKernelContext* context) {
-        auto function_state = static_cast<OpenVINOEPFunctionState*>(state);
-        try {
-          function_state->backend_manager->Compute(context);
-        } catch (const std::exception& ex) {
-          return common::Status(common::ONNXRUNTIME, common::FAIL, ex.what());
-        }
-        return Status::OK();
-      };
 
-      compute_info.release_state_func =
-          [](FunctionState state) {
-            if (state) {
-              OpenVINOEPFunctionState* function_state = static_cast<OpenVINOEPFunctionState*>(state);
-              delete function_state;
-            }
-          };
-      node_compute_funcs.push_back(compute_info);
-    } catch (const OnnxRuntimeException& ex) {
-      std::string exception_str = ex.what();
-      if (exception_str.find("ZE_RESULT_ERROR_UNKNOWN") != std::string::npos ||
-          exception_str.find("ZE_RESULT_ERROR_UNINITIALIZED") != std::string::npos) {
-        return Status(common::ONNXRUNTIME, common::EP_FAIL, "Model needs to be recompiled");
-      } else {
-        ORT_THROW(exception_str);
+    std::shared_ptr<openvino_ep::BackendManager> backend_manager =
+        std::make_shared<openvino_ep::BackendManager>(*global_context_,
+                                                      fused_node,
+                                                      graph_body_viewer,
+                                                      *GetLogger(),
+                                                      ep_ctx_handle_);
+
+    compute_info.create_state_func =
+        [backend_manager](ComputeContext* context, FunctionState* state) {
+          OpenVINOEPFunctionState* p = new OpenVINOEPFunctionState();
+          p->allocate_func = context->allocate_func;
+          p->destroy_func = context->release_func;
+          p->allocator_handle = context->allocator_handle;
+          p->backend_manager = backend_manager;
+          *state = static_cast<FunctionState>(p);
+          return 0;
+        };
+    compute_info.compute_func = [](FunctionState state, const OrtApi* /* api */, OrtKernelContext* context) {
+      auto function_state = static_cast<OpenVINOEPFunctionState*>(state);
+      try {
+        function_state->backend_manager->Compute(context);
+      } catch (const std::exception& ex) {
+        return common::Status(common::ONNXRUNTIME, common::FAIL, ex.what());
       }
-    }
+      return Status::OK();
+    };
+
+    compute_info.release_state_func =
+        [](FunctionState state) {
+          if (state) {
+            OpenVINOEPFunctionState* function_state = static_cast<OpenVINOEPFunctionState*>(state);
+            delete function_state;
+          }
+        };
+    node_compute_funcs.push_back(compute_info);
   }
 
   return Status::OK();


### PR DESCRIPTION
### Description
* OVEP catches the NPU driver exception and return failure status
* NPU to CPU fallback is disabled when inferencing with blob
 
### Motivation and Context
* When the NPU driver version of blob creation and inference differs, it fails with NPU driver exception. Handled that exception and throw meaningful exception message
* Restricted the NPU to CPU fallback when inferencing with blob