### PR TITLE
Ericcraw/ort allocator hacking

### DIFF
--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -50,7 +50,14 @@ constexpr const char* HIP = "Hip";
 constexpr const char* HIP_PINNED = "HipPinned";
 constexpr const char* OpenVINO_CPU = "OpenVINO_CPU";
 constexpr const char* OpenVINO_GPU = "OpenVINO_GPU";
+constexpr const char* OpenVINO_NPU = "OpenVINO_RT_NPU";
+
+// application
+// 1. Allocate with ORT::CreateTensor("<custom_allocator_tag>")
+// 2. "Manual" allocation
+
 constexpr const char* OpenVINO_RT = "OpenVINO_RT";
+constexpr const char* OpenVINO_RT_NPU = "OpenVINO_RT_NPU";
 constexpr const char* WIN32_HANDLE = "WIN32_HANDLE";
 constexpr const char* WEBGPU_BUFFER = "WebGPU_Buffer";
 

--- a/include/onnxruntime/core/framework/allocator.h
+++ b/include/onnxruntime/core/framework/allocator.h
@@ -50,6 +50,8 @@ constexpr const char* HIP = "Hip";
 constexpr const char* HIP_PINNED = "HipPinned";
 constexpr const char* OpenVINO_CPU = "OpenVINO_CPU";
 constexpr const char* OpenVINO_GPU = "OpenVINO_GPU";
+constexpr const char* OpenVINO_RT = "OpenVINO_RT";
+constexpr const char* WIN32_HANDLE = "WIN32_HANDLE";
 constexpr const char* WEBGPU_BUFFER = "WebGPU_Buffer";
 
 constexpr size_t kAllocAlignment = 256;

--- a/onnxruntime/core/framework/allocator.cc
+++ b/onnxruntime/core/framework/allocator.cc
@@ -145,6 +145,10 @@ ORT_API_STATUS_IMPL(OrtApis::CreateMemoryInfo, _In_ const char* name1, enum OrtA
     *out = new OrtMemoryInfo(
         name1, type, OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id1)), id1,
         mem_type1);
+  } else if (strcmp(name1, onnxruntime::OpenVINO_RT_NPU) == 0) {
+    *out = new OrtMemoryInfo(
+        name1, type, OrtDevice(OrtDevice::NPU, OrtDevice::MemType::DEFAULT, static_cast<OrtDevice::DeviceId>(id1)), id1,
+        mem_type1);
   } else if (strcmp(name1, onnxruntime::CUDA_PINNED) == 0) {
     *out = new OrtMemoryInfo(
         onnxruntime::CUDA_PINNED, type, OrtDevice(OrtDevice::CPU, OrtDevice::MemType::CUDA_PINNED, static_cast<OrtDevice::DeviceId>(id1)),

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -14,6 +14,11 @@
 #include "core/providers/openvino/onnx_ctx_model_helper.h"
 #include "core/providers/openvino/backend_manager.h"
 
+#include <CL\cl_ext.h>
+#include <openvino/runtime/intel_gpu/ocl/ocl.hpp>
+
+#pragma comment(lib, "opencl")
+
 namespace onnxruntime {
 
 namespace openvino_ep {
@@ -287,16 +292,144 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
           ORT_THROW(msg);
         }
       } else {
-        OVTensorPtr graph_input_blob;
+        auto tensor = context.GetInput(subgraph_context_.input_names.at(input_name));
+        auto allocator_name = tensor.GetTensorMemoryInfo().GetAllocatorName();
+        ov_tensor_data_t ov_tensor_key;
+        ort_tensor_key_t ort_tensor_key{tensor.GetTensorRawData(), allocator_name};
+        if (const auto& it = ort_ov_tensor_map.find(ort_tensor_key); it != ort_ov_tensor_map.end()) {
+          ov_tensor_key = it->second;
+        } else {
+          if (allocator_name == OpenVINO_RT) {
+            auto tensor_info = tensor.GetTensorTypeAndShapeInfo();
+            auto tensor_shape = tensor_info.GetShape();
+            auto tensor_size = tensor_shape.size();
+            ov::Shape input_tensor_shape = ov::Shape(tensor_size, 0);
+            const char* tensor_data = tensor.GetTensorData<char>();
+            std::map<ONNXTensorElementDataType, ov::element::Type> ov_type_convert{
+                {ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ov::element::f32}};
+            auto ov_type = ov_type_convert[tensor_info.GetElementType()];
+            ov_tensor_key.tensor_ptr = std::make_shared<ov::Tensor>(ov_type, input_tensor_shape,
+                                                                    (void*)tensor_data);
+            ov_tensor_key.copy_needed = false;
+          } else if (allocator_name == WIN32_HANDLE) {
+            const void* tensor_data = tensor.GetTensorRawData();
+            auto remote_context_ = global_context_.ie_core.Get().get_default_context("GPU").as<ov::intel_gpu::ocl::ClContext>();
+            cl_context ctx = remote_context_.get();
+
+            cl_mem_properties extMemProperties[] = {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR, (cl_mem_properties)tensor_data,
+                                                    0};
+            cl_int errcode = 0;
+            auto shape = input_info_iter->get_shape();
+            size_t elem_count = std::reduce(
+                shape.begin()++, shape.end(), *shape.begin(), std::multiplies<>());
+            auto elem_size = input_info_iter->get_element_type().bitwidth();
+            cl_mem extMemBuffer =
+                clCreateBufferWithProperties(remote_context_, extMemProperties, 0, elem_count * elem_size, nullptr, &errcode);
+            auto remote_tensor =
+                remote_context_.create_tensor(input_info_iter->get_element_type(), input_info_iter->get_shape(), extMemBuffer);
+            ov_tensor_key.tensor_ptr = std::make_shared<ov::Tensor>(remote_tensor);
+            ov_tensor_key.copy_needed = false;
+
+          } else {
+            auto remote_context_ = global_context_.ie_core.Get().get_default_context("GPU").as<ov::intel_gpu::ocl::ClContext>();
+            auto remote_tensor = remote_context_.create_host_tensor(input_info_iter->get_element_type(), input_info_iter->get_shape());
+            ov_tensor_key.tensor_ptr = std::make_shared<ov::Tensor>(remote_tensor);
+            ov_tensor_key.copy_needed = true;
+          }
+
+          ort_ov_tensor_map.emplace(ort_tensor_key, ov_tensor_key);
+        }
+
+        if (ov_tensor_key.copy_needed) {
+          const char* ort_tensor_data = tensor.GetTensorData<char>();
+          size_t tensor_data_size = ov_tensor_key.tensor_ptr->get_byte_size();
+          auto ort_batch_memory_offset = ort_tensor_data + tensor_data_size * batch_slice_idx;
+          std::memcpy(ov_tensor_key.tensor_ptr->data(), ort_batch_memory_offset, tensor_data_size);
+        }
+
         try {
-          graph_input_blob = infer_request->GetTensor(input_name);
+          infer_request->SetTensor(input_name, ov_tensor_key.tensor_ptr);
         } catch (const char* msg) {
           ORT_THROW(msg);
         }
-        FillInputBlob(std::move(graph_input_blob), batch_slice_idx, std::move(input_name), context, subgraph_context_);
       }
       input_idx++;
     }
+
+    // Set the output blob as remote blob
+    auto graph_output_info = exe_network_.Get().outputs();
+    for (auto output_info_iter = graph_output_info.begin();
+         output_info_iter != graph_output_info.end(); ++output_info_iter) {
+      auto output_names = output_info_iter->get_names();
+      std::string onnx_output_name;
+      std::string output_name;
+      bool output_name_found = false;
+      // using the output name retrieved from ONNX original to match with the output names returned by OV tensors
+      for (auto it = subgraph_context_.output_names.begin(); it != subgraph_context_.output_names.end(); ++it) {
+        onnx_output_name = it->first;
+        if (output_names.find(onnx_output_name) != output_names.end()) {
+          // Assigning the output_name
+          output_name = it->first;
+          output_name_found = true;
+          break;
+        }
+      }
+      if (!output_name_found) {
+        ORT_THROW(
+            log_tag +
+            "Output names mismatch between OpenVINO and ONNX. [ONNX Output: ] " +
+            onnx_output_name + " doesn't exist in the list of OpenVINO output tensor names");
+      }
+
+      size_t batch_size = 1;
+      Ort::UnownedValue tensor = GetOutputTensor(context,
+                                                 batch_size,
+                                                 infer_request,
+                                                 output_name,
+                                                 subgraph_context_.output_names);
+      auto allocator_name = tensor.GetTensorMemoryInfo().GetAllocatorName();
+
+      ov_tensor_data_t ov_tensor_data;
+      ort_tensor_key_t ort_tensor_key{tensor.GetTensorRawData(), allocator_name};
+      if (const auto& it = ort_ov_tensor_map.find(ort_tensor_key); it != ort_ov_tensor_map.end()) {
+        ov_tensor_data = it->second;
+      } else {
+        // Check if ORT Value wraps a device pointer
+        if (allocator_name == WIN32_HANDLE) {
+          const void* tensor_data = tensor.GetTensorRawData();
+          auto remote_context_ = global_context_.ie_core.Get().get_default_context("GPU").as<ov::intel_gpu::ocl::ClContext>();
+          cl_context ctx = remote_context_.get();
+
+          cl_mem_properties extMemProperties[] = {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR, (cl_mem_properties)tensor_data,
+                                                  0};
+          cl_int errcode = 0;
+          auto shape = output_info_iter->get_shape();
+          size_t elem_count = std::reduce(
+              shape.begin()++, shape.end(), *shape.begin(), std::multiplies<>());
+          auto elem_size = output_info_iter->get_element_type().bitwidth();
+          cl_mem extMemBuffer =
+              clCreateBufferWithProperties(remote_context_, extMemProperties, 0, elem_count * elem_size, nullptr, &errcode);
+          auto remote_tensor =
+              remote_context_.create_tensor(output_info_iter->get_element_type(), output_info_iter->get_shape(), extMemBuffer);
+          ov::Tensor tensor_t = static_cast<ov::Tensor>(remote_tensor);
+          ov_tensor_data.tensor_ptr = std::make_shared<ov::Tensor>(tensor_t);
+          ov_tensor_data.copy_needed = false;
+        } else if (allocator_name == CPU) {
+          auto remote_context_ = global_context_.ie_core.Get().get_default_context("GPU").as<ov::intel_gpu::ocl::ClContext>();
+          auto remote_tensor = remote_context_.create_host_tensor(output_info_iter->get_element_type(), output_info_iter->get_shape());
+          ov_tensor_data.tensor_ptr = std::make_shared<ov::Tensor>(remote_tensor);
+          ov_tensor_data.copy_needed = true;
+        }
+        ort_ov_tensor_map.emplace(ort_tensor_key, ov_tensor_data);
+      }
+
+      try {
+        infer_request->SetTensor(output_name, ov_tensor_data.tensor_ptr);
+      } catch (const char* msg) {
+        ORT_THROW(msg);
+      }
+    }
+
     // Start Async inference
     infer_request->StartAsync();
   } catch (const char* msg) {
@@ -422,7 +555,6 @@ void BasicBackend::CompleteAsyncInference(Ort::KernelContext& context, OVInferRe
     auto graph_output_info = exe_network_.Get().outputs();
     for (auto output_info_iter = graph_output_info.begin();
          output_info_iter != graph_output_info.end(); ++output_info_iter) {
-      OVTensorPtr graph_output_blob;
       auto output_names = output_info_iter->get_names();
       std::string onnx_output_name;
       std::string output_name;
@@ -446,20 +578,24 @@ void BasicBackend::CompleteAsyncInference(Ort::KernelContext& context, OVInferRe
             " doesn't exist in the "
             "list of OpenVINO output tensor names");
       }
-      try {
-        graph_output_blob = infer_request->GetTensor(output_name);
-      } catch (const char* msg) {
-        ORT_THROW(msg);
-      }
+
       size_t batch_size = 1;
       Ort::UnownedValue output_tensor =
           GetOutputTensor(context, batch_size, infer_request, std::move(output_name), subgraph_context_.output_names);
-      auto mem_info = output_tensor.GetTensorMemoryInfo();
-      if (mem_info.GetAllocatorName() == OpenVINO_GPU) {
-        return;
+      auto allocator_name = output_tensor.GetTensorMemoryInfo().GetAllocatorName();
+      ov_tensor_data_t ov_tensor_data;
+      ort_tensor_key_t ort_tensor_key{output_tensor.GetTensorRawData(), allocator_name};
+      if (const auto& it = ort_ov_tensor_map.find(ort_tensor_key); it != ort_ov_tensor_map.end()) {
+        ov_tensor_data = it->second;
       } else {
-        size_t batch_slice = 0;
-        FillOutputBlob(std::move(graph_output_blob), output_tensor, batch_slice);
+        ORT_THROW(log_tag + "Expected all outputs to have associated OV::Tensor's");
+      }
+
+      if (ov_tensor_data.copy_needed) {
+        auto ort_tensor_data = output_tensor.GetTensorMutableData<char>();
+        size_t tensor_data_size = ov_tensor_data.tensor_ptr->get_byte_size();
+        auto ort_batch_memory_offset = ort_tensor_data /*+ tensor_data_size * batch_size*/;
+        std::memcpy(ort_batch_memory_offset, ov_tensor_data.tensor_ptr->data(), tensor_data_size);
       }
     }
 

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -14,11 +14,6 @@
 #include "core/providers/openvino/onnx_ctx_model_helper.h"
 #include "core/providers/openvino/backend_manager.h"
 
-#include <CL\cl_ext.h>
-#include <openvino/runtime/intel_gpu/ocl/ocl.hpp>
-
-#pragma comment(lib, "opencl")
-
 namespace onnxruntime {
 
 namespace openvino_ep {
@@ -259,6 +254,12 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
                   "Input names mismatch between OpenVINO and ONNX. " + onnx_input_name +
                   " doesn't exist in the list of OpenVINO input tensor names");
       }
+      auto ort_shape_to_ovshape = [](const std::vector<int64_t>& shape) {
+        ov::Shape ov_shape(shape.size());
+        std::copy(shape.begin(), shape.end(), ov_shape.begin());
+        return ov_shape;
+      };
+
       size_t batch_slice_idx = 0;
       if (subgraph_context_.has_dynamic_input_shape &&
           !global_context_.disable_dynamic_shapes &&
@@ -299,44 +300,19 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
         if (const auto& it = ort_ov_tensor_map.find(ort_tensor_key); it != ort_ov_tensor_map.end()) {
           ov_tensor_key = it->second;
         } else {
-          if (allocator_name == OpenVINO_RT) {
-            auto tensor_info = tensor.GetTensorTypeAndShapeInfo();
-            auto tensor_shape = tensor_info.GetShape();
-            auto tensor_size = tensor_shape.size();
-            ov::Shape input_tensor_shape = ov::Shape(tensor_size, 0);
-            const char* tensor_data = tensor.GetTensorData<char>();
-            std::map<ONNXTensorElementDataType, ov::element::Type> ov_type_convert{
-                {ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ov::element::f32}};
-            auto ov_type = ov_type_convert[tensor_info.GetElementType()];
-            ov_tensor_key.tensor_ptr = std::make_shared<ov::Tensor>(ov_type, input_tensor_shape,
-                                                                    (void*)tensor_data);
+          // Does this make sense for both types of allocators?
+          auto input = ie_cnn_network_->get_parameters().at(input_idx);
+          ov_tensor_key.tensor_ptr = std::make_shared<ov::Tensor>(input->get_element_type(), input->get_shape(),
+                                                                    (void*)tensor.GetTensorRawData());
+          if (allocator_name == OpenVINO_RT_NPU) {
+            // do we need this??
+            // auto tensor_info = tensor.GetTensorTypeAndShapeInfo();
+            // auto tensor_shape = tensor_info.GetShape();
+            // auto tensor_size = tensor_shape.size();
             ov_tensor_key.copy_needed = false;
-          } else if (allocator_name == WIN32_HANDLE) {
-            const void* tensor_data = tensor.GetTensorRawData();
-            auto remote_context_ = global_context_.ie_core.Get().get_default_context("GPU").as<ov::intel_gpu::ocl::ClContext>();
-            cl_context ctx = remote_context_.get();
-
-            cl_mem_properties extMemProperties[] = {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR, (cl_mem_properties)tensor_data,
-                                                    0};
-            cl_int errcode = 0;
-            auto shape = input_info_iter->get_shape();
-            size_t elem_count = std::reduce(
-                shape.begin()++, shape.end(), *shape.begin(), std::multiplies<>());
-            auto elem_size = input_info_iter->get_element_type().bitwidth();
-            cl_mem extMemBuffer =
-                clCreateBufferWithProperties(remote_context_, extMemProperties, 0, elem_count * elem_size, nullptr, &errcode);
-            auto remote_tensor =
-                remote_context_.create_tensor(input_info_iter->get_element_type(), input_info_iter->get_shape(), extMemBuffer);
-            ov_tensor_key.tensor_ptr = std::make_shared<ov::Tensor>(remote_tensor);
-            ov_tensor_key.copy_needed = false;
-
           } else {
-            auto remote_context_ = global_context_.ie_core.Get().get_default_context("GPU").as<ov::intel_gpu::ocl::ClContext>();
-            auto remote_tensor = remote_context_.create_host_tensor(input_info_iter->get_element_type(), input_info_iter->get_shape());
-            ov_tensor_key.tensor_ptr = std::make_shared<ov::Tensor>(remote_tensor);
             ov_tensor_key.copy_needed = true;
           }
-
           ort_ov_tensor_map.emplace(ort_tensor_key, ov_tensor_key);
         }
 
@@ -358,6 +334,7 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
 
     // Set the output blob as remote blob
     auto graph_output_info = exe_network_.Get().outputs();
+    auto output_idx = 0;
     for (auto output_info_iter = graph_output_info.begin();
          output_info_iter != graph_output_info.end(); ++output_info_iter) {
       auto output_names = output_info_iter->get_names();
@@ -394,30 +371,12 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
       if (const auto& it = ort_ov_tensor_map.find(ort_tensor_key); it != ort_ov_tensor_map.end()) {
         ov_tensor_data = it->second;
       } else {
-        // Check if ORT Value wraps a device pointer
-        if (allocator_name == WIN32_HANDLE) {
-          const void* tensor_data = tensor.GetTensorRawData();
-          auto remote_context_ = global_context_.ie_core.Get().get_default_context("GPU").as<ov::intel_gpu::ocl::ClContext>();
-          cl_context ctx = remote_context_.get();
-
-          cl_mem_properties extMemProperties[] = {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR, (cl_mem_properties)tensor_data,
-                                                  0};
-          cl_int errcode = 0;
-          auto shape = output_info_iter->get_shape();
-          size_t elem_count = std::reduce(
-              shape.begin()++, shape.end(), *shape.begin(), std::multiplies<>());
-          auto elem_size = output_info_iter->get_element_type().bitwidth();
-          cl_mem extMemBuffer =
-              clCreateBufferWithProperties(remote_context_, extMemProperties, 0, elem_count * elem_size, nullptr, &errcode);
-          auto remote_tensor =
-              remote_context_.create_tensor(output_info_iter->get_element_type(), output_info_iter->get_shape(), extMemBuffer);
-          ov::Tensor tensor_t = static_cast<ov::Tensor>(remote_tensor);
-          ov_tensor_data.tensor_ptr = std::make_shared<ov::Tensor>(tensor_t);
+        auto output = ie_cnn_network_->get_results().at(output_idx);
+        ov_tensor_data.tensor_ptr = std::make_shared<ov::Tensor>(output->get_element_type(), output->get_shape(),
+                                                                 (void*)tensor.GetTensorRawData());
+        if(allocator_name == OpenVINO_RT_NPU) {
           ov_tensor_data.copy_needed = false;
-        } else if (allocator_name == CPU) {
-          auto remote_context_ = global_context_.ie_core.Get().get_default_context("GPU").as<ov::intel_gpu::ocl::ClContext>();
-          auto remote_tensor = remote_context_.create_host_tensor(output_info_iter->get_element_type(), output_info_iter->get_shape());
-          ov_tensor_data.tensor_ptr = std::make_shared<ov::Tensor>(remote_tensor);
+        } else {
           ov_tensor_data.copy_needed = true;
         }
         ort_ov_tensor_map.emplace(ort_tensor_key, ov_tensor_data);
@@ -428,6 +387,7 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
       } catch (const char* msg) {
         ORT_THROW(msg);
       }
+      output_idx++;
     }
 
     // Start Async inference

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -314,6 +314,12 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
             ov_tensor_key.copy_needed = true;
           }
           ort_ov_tensor_map.emplace(ort_tensor_key, ov_tensor_key);
+
+          try {
+            infer_request->SetTensor(input_name, ov_tensor_key.tensor_ptr);
+          } catch (const char* msg) {
+            ORT_THROW(msg);
+          }
         }
 
         if (ov_tensor_key.copy_needed) {
@@ -321,12 +327,6 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
           size_t tensor_data_size = ov_tensor_key.tensor_ptr->get_byte_size();
           auto ort_batch_memory_offset = ort_tensor_data + tensor_data_size * batch_slice_idx;
           std::memcpy(ov_tensor_key.tensor_ptr->data(), ort_batch_memory_offset, tensor_data_size);
-        }
-
-        try {
-          infer_request->SetTensor(input_name, ov_tensor_key.tensor_ptr);
-        } catch (const char* msg) {
-          ORT_THROW(msg);
         }
       }
       input_idx++;
@@ -380,13 +380,14 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
           ov_tensor_data.copy_needed = true;
         }
         ort_ov_tensor_map.emplace(ort_tensor_key, ov_tensor_data);
+
+        try {
+          infer_request->SetTensor(output_name, ov_tensor_data.tensor_ptr);
+        } catch (const char* msg) {
+          ORT_THROW(msg);
+        }
       }
 
-      try {
-        infer_request->SetTensor(output_name, ov_tensor_data.tensor_ptr);
-      } catch (const char* msg) {
-        ORT_THROW(msg);
-      }
       output_idx++;
     }
 

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <condition_variable>
 #include <mutex>
+#include <map>
 
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/providers/openvino/contexts.h"
@@ -19,6 +20,11 @@
 
 namespace onnxruntime {
 namespace openvino_ep {
+
+struct ov_tensor_data_t {
+  OVTensorPtr tensor_ptr;
+  bool copy_needed;
+};
 
 class InferRequestsQueue;
 class BasicBackend : public IBackend {
@@ -60,6 +66,9 @@ class BasicBackend : public IBackend {
 #if defined IO_BUFFER_ENABLED
   OVRemoteContextPtr remote_context_;
 #endif
+
+  using ort_tensor_key_t = std::pair<const void *, const std::string>;
+  std::map<ort_tensor_key_t, ov_tensor_data_t> ort_ov_tensor_map;
 };
 
 class InferRequestsQueue {

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -10,6 +10,7 @@
 #include "core/providers/openvino/onnx_ctx_model_helper.h"
 #include "core/providers/openvino/ov_versions/capability.h"
 #include "openvino/core/version.hpp"
+#include "core/providers/openvino/ov_allocator.h"
 
 #define MEMCPY_S(dest, src, destsz, srcsz) memcpy(dest, src, std::min(destsz, srcsz))
 
@@ -178,6 +179,18 @@ common::Status OpenVINOExecutionProvider::Compile(
   }
 
   return Status::OK();
+}
+
+std::vector<AllocatorPtr> OpenVINOExecutionProvider::CreatePreferredAllocators() {
+  AllocatorCreationInfo npu_allocator_info {
+    [](OrtDevice::DeviceId device_id) {
+      return std::make_unique<OVRTAllocator>(OrtDevice::NPU, device_id, OpenVINO_RT_NPU);
+    },
+    0,
+  };
+
+  // fill in allocator
+  return std::vector<AllocatorPtr>{CreateAllocator(npu_allocator_info)};
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -183,8 +183,8 @@ common::Status OpenVINOExecutionProvider::Compile(
 
 std::vector<AllocatorPtr> OpenVINOExecutionProvider::CreatePreferredAllocators() {
   AllocatorCreationInfo npu_allocator_info {
-    [](OrtDevice::DeviceId device_id) {
-      return std::make_unique<OVRTAllocator>(OrtDevice::NPU, device_id, OpenVINO_RT_NPU);
+    [this](OrtDevice::DeviceId device_id) {
+        return std::make_unique<OVRTAllocator>(global_context_->ie_core.Get(), OrtDevice::NPU, device_id, OpenVINO_RT_NPU);
     },
     0,
   };

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -190,6 +190,8 @@ class OpenVINOExecutionProvider : public IExecutionProvider {
     return nullptr;
   }
 
+  std::vector<AllocatorPtr> CreatePreferredAllocators() override;
+
  private:
   std::unique_ptr<openvino_ep::GlobalContext> global_context_;
   openvino_ep::EPCtxHandler ep_ctx_handle_{};

--- a/onnxruntime/core/providers/openvino/ov_allocator.cc
+++ b/onnxruntime/core/providers/openvino/ov_allocator.cc
@@ -27,9 +27,10 @@ OVRTAllocator::OVRTAllocator(ov::Core& core, OrtDevice::DeviceType device_type, 
 void* OVRTAllocator::Alloc(size_t size) {
   try {
     size_t alloc_size = align_up(size + sizeof(ov::Tensor*) + default_alignment, default_alignment);
-    ov::Tensor* tensor = new ov::Tensor(remote_ctx_.create_host_tensor(ov::element::Type_t::u8,
-                                                                       { alloc_size }));
-    uintptr_t data_ptr = reinterpret_cast<uintptr_t>(tensor->data());
+
+    ov::intel_npu::level_zero::ZeroContext npu_ctx = remote_ctx_.as<ov::intel_npu::level_zero::ZeroContext>();
+    auto tensor = new ov::intel_npu::level_zero::ZeroBufferTensor(npu_ctx.create_l0_host_tensor(ov::element::Type_t::u8, {alloc_size}, ov::intel_npu::TensorType::INPUT));
+    uintptr_t data_ptr = reinterpret_cast<uintptr_t>(tensor->get());
 
     ov::Tensor** ptr = reinterpret_cast<ov::Tensor**>(align_up(data_ptr + sizeof(ov::Tensor*), default_alignment));
     ptr[-1] = tensor;

--- a/onnxruntime/core/providers/openvino/ov_allocator.cc
+++ b/onnxruntime/core/providers/openvino/ov_allocator.cc
@@ -27,10 +27,9 @@ OVRTAllocator::OVRTAllocator(ov::Core& core, OrtDevice::DeviceType device_type, 
 void* OVRTAllocator::Alloc(size_t size) {
   try {
     size_t alloc_size = align_up(size + sizeof(ov::Tensor*) + default_alignment, default_alignment);
-
-    ov::intel_npu::level_zero::ZeroContext npu_ctx = remote_ctx_.as<ov::intel_npu::level_zero::ZeroContext>();
-    auto tensor = new ov::intel_npu::level_zero::ZeroBufferTensor(npu_ctx.create_l0_host_tensor(ov::element::Type_t::u8, {alloc_size}, ov::intel_npu::TensorType::INPUT));
-    uintptr_t data_ptr = reinterpret_cast<uintptr_t>(tensor->get());
+    ov::Tensor* tensor = new ov::Tensor(remote_ctx_.create_host_tensor(ov::element::Type_t::u8,
+                                                                       { alloc_size }));
+    uintptr_t data_ptr = reinterpret_cast<uintptr_t>(tensor->data());
 
     ov::Tensor** ptr = reinterpret_cast<ov::Tensor**>(align_up(data_ptr + sizeof(ov::Tensor*), default_alignment));
     ptr[-1] = tensor;

--- a/onnxruntime/core/providers/openvino/ov_allocator.cc
+++ b/onnxruntime/core/providers/openvino/ov_allocator.cc
@@ -1,0 +1,44 @@
+// Copyright (C) Intel Corporation
+// Licensed under the MIT License
+
+#include "core/providers/openvino/ov_allocator.h"
+#include "core/providers/openvino/ov_interface.h"
+#include "openvino/runtime/intel_npu/level_zero/level_zero.hpp"
+#include "openvino/runtime/intel_npu/properties.hpp"
+
+namespace onnxruntime {
+
+using namespace openvino_ep;
+
+OVRTAllocator::OVRTAllocator(OrtDevice::DeviceType device_type, OrtDevice::DeviceId device_id, const char* name) : IAllocator(OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator, OrtDevice(device_type, OrtDevice::MemType::DEFAULT, device_id), device_id, OrtMemTypeCPUInput)) {
+    if(device_type == OrtDevice::NPU) {
+        ov::Core core;
+        remote_ctx_ = core.get_default_context("NPU").as<ov::intel_npu::level_zero::ZeroContext>();
+    } else {
+        ORT_THROW("Invalid device type");
+    }
+}
+
+void* OVRTAllocator::Alloc(size_t size) {
+  try {
+      // TODO: probably want to handle alignment
+    ov::Tensor* tensor = new ov::Tensor(remote_ctx_.create_host_tensor(ov::element::Type_t::u8, {size + sizeof(ov::Tensor*)}));
+    ov::Tensor** ptr = reinterpret_cast<ov::Tensor**>(tensor->data());
+    *ptr = tensor;
+    return reinterpret_cast <void*>(ptr + 1);
+  } catch (const ov::Exception& e) {
+    ORT_THROW(std::string("Alloc failed: ") + e.what());
+  }
+  return nullptr;
+}
+
+void OVRTAllocator::Free(void* p) {
+  try {
+    ov::Tensor **ptr = reinterpret_cast<ov::Tensor**>(p);
+    delete ptr[-1];
+  } catch (const ov::Exception& e) {
+    ORT_THROW(std::string("Free failed: ") + e.what());
+    }
+  }
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/ov_allocator.cc
+++ b/onnxruntime/core/providers/openvino/ov_allocator.cc
@@ -10,21 +10,32 @@ namespace onnxruntime {
 
 using namespace openvino_ep;
 
-OVRTAllocator::OVRTAllocator(ov::Core &core, OrtDevice::DeviceType device_type, OrtDevice::DeviceId device_id, const char* name) : IAllocator(OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator, OrtDevice(device_type, OrtDevice::MemType::DEFAULT, device_id), device_id, OrtMemTypeCPUInput)), core_(core) {
-    if(device_type == OrtDevice::NPU) {
-        remote_ctx_ = core_.get_default_context("NPU").as<ov::intel_npu::level_zero::ZeroContext>();
-    } else {
-        ORT_THROW("Invalid device type");
-    }
+constexpr size_t default_alignment = 4096;
+
+static inline size_t align_up(size_t size, size_t pow2_alignment) {
+  return (size + pow2_alignment - 1) & ~(pow2_alignment - 1);
+}
+
+OVRTAllocator::OVRTAllocator(ov::Core& core, OrtDevice::DeviceType device_type, OrtDevice::DeviceId device_id, const char* name) : IAllocator(OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator, OrtDevice(device_type, OrtDevice::MemType::DEFAULT, device_id), device_id, OrtMemTypeCPUInput)), core_(core) {
+  if (device_type == OrtDevice::NPU) {
+    remote_ctx_ = core_.get_default_context("NPU").as<ov::intel_npu::level_zero::ZeroContext>();
+  } else {
+    ORT_THROW("Invalid device type");
+  }
 }
 
 void* OVRTAllocator::Alloc(size_t size) {
   try {
-      // TODO: probably want to handle alignment
-    ov::Tensor* tensor = new ov::Tensor(remote_ctx_.create_host_tensor(ov::element::Type_t::u8, {size + sizeof(ov::Tensor*)}));
-    ov::Tensor** ptr = reinterpret_cast<ov::Tensor**>(tensor->data());
-    *ptr = tensor;
-    return reinterpret_cast <void*>(ptr + 1);
+    size_t alloc_size = align_up(size + sizeof(ov::Tensor*) + default_alignment, default_alignment);
+    ov::Tensor* tensor = new ov::Tensor(remote_ctx_.create_host_tensor(ov::element::Type_t::u8,
+                                                                       { alloc_size }));
+    uintptr_t data_ptr = reinterpret_cast<uintptr_t>(tensor->data());
+
+    ov::Tensor** ptr = reinterpret_cast<ov::Tensor**>(align_up(data_ptr + sizeof(ov::Tensor*), default_alignment));
+    ptr[-1] = tensor;
+
+    return reinterpret_cast<void*>(ptr);
+
   } catch (const ov::Exception& e) {
     ORT_THROW(std::string("Alloc failed: ") + e.what());
   }
@@ -33,11 +44,11 @@ void* OVRTAllocator::Alloc(size_t size) {
 
 void OVRTAllocator::Free(void* p) {
   try {
-    ov::Tensor **ptr = reinterpret_cast<ov::Tensor**>(p);
+    ov::Tensor** ptr = reinterpret_cast<ov::Tensor**>(p);
     delete ptr[-1];
   } catch (const ov::Exception& e) {
     ORT_THROW(std::string("Free failed: ") + e.what());
-    }
   }
+}
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/ov_allocator.cc
+++ b/onnxruntime/core/providers/openvino/ov_allocator.cc
@@ -10,10 +10,9 @@ namespace onnxruntime {
 
 using namespace openvino_ep;
 
-OVRTAllocator::OVRTAllocator(OrtDevice::DeviceType device_type, OrtDevice::DeviceId device_id, const char* name) : IAllocator(OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator, OrtDevice(device_type, OrtDevice::MemType::DEFAULT, device_id), device_id, OrtMemTypeCPUInput)) {
+OVRTAllocator::OVRTAllocator(ov::Core &core, OrtDevice::DeviceType device_type, OrtDevice::DeviceId device_id, const char* name) : IAllocator(OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator, OrtDevice(device_type, OrtDevice::MemType::DEFAULT, device_id), device_id, OrtMemTypeCPUInput)), core_(core) {
     if(device_type == OrtDevice::NPU) {
-        ov::Core core;
-        remote_ctx_ = core.get_default_context("NPU").as<ov::intel_npu::level_zero::ZeroContext>();
+        remote_ctx_ = core_.get_default_context("NPU").as<ov::intel_npu::level_zero::ZeroContext>();
     } else {
         ORT_THROW("Invalid device type");
     }

--- a/onnxruntime/core/providers/openvino/ov_allocator.h
+++ b/onnxruntime/core/providers/openvino/ov_allocator.h
@@ -1,0 +1,23 @@
+// Copyright (C) Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+
+#include "core/common/inlined_containers.h"
+#include "core/framework/allocator.h"
+#include "openvino/runtime/remote_context.hpp"
+
+
+namespace onnxruntime {
+
+class OVRTAllocator : public IAllocator {
+ public:
+  OVRTAllocator(OrtDevice::DeviceType device_type, OrtDevice::DeviceId device_id, const char* name);
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
+
+ private:
+    ov::RemoteContext remote_ctx_;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/ov_allocator.h
+++ b/onnxruntime/core/providers/openvino/ov_allocator.h
@@ -12,11 +12,12 @@ namespace onnxruntime {
 
 class OVRTAllocator : public IAllocator {
  public:
-  OVRTAllocator(OrtDevice::DeviceType device_type, OrtDevice::DeviceId device_id, const char* name);
+  OVRTAllocator(ov::Core &core, OrtDevice::DeviceType device_type, OrtDevice::DeviceId device_id, const char* name);
   void* Alloc(size_t size) override;
   void Free(void* p) override;
 
  private:
+    ov::Core &core_;
     ov::RemoteContext remote_ctx_;
 };
 

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -838,7 +838,10 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
   }
   size_t output_count = session_.GetOutputCount();
   output_names_.resize(output_count);
-  Ort::AllocatorWithDefaultOptions a;
+
+  Ort::MemoryInfo memory_info = Ort::MemoryInfo("OpenVINO_RT_NPU", OrtArenaAllocator, 0, OrtMemTypeCPUOutput);
+  Ort::Allocator a(session_, memory_info);
+
   for (size_t i = 0; i != output_count; ++i) {
     auto output_name = session_.GetOutputNameAllocated(i, a);
     assert(output_name != nullptr);

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -838,10 +838,7 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
   }
   size_t output_count = session_.GetOutputCount();
   output_names_.resize(output_count);
-
-  Ort::MemoryInfo memory_info = Ort::MemoryInfo("OpenVINO_RT_NPU", OrtArenaAllocator, 0, OrtMemTypeCPUOutput);
-  Ort::Allocator a(session_, memory_info);
-
+  Ort::AllocatorWithDefaultOptions a;
   for (size_t i = 0; i != output_count; ++i) {
     auto output_name = session_.GetOutputNameAllocated(i, a);
     assert(output_name != nullptr);

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -940,7 +940,7 @@ bool OnnxRuntimeTestSession::PopulateGeneratedInputTestData(int32_t seed) {
   // iterate over all input nodes
   for (size_t i = 0; i < static_cast<size_t>(input_length_); i++) {
     Ort::TypeInfo type_info = session_.GetInputTypeInfo(i);
-    Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    Ort::MemoryInfo memory_info = Ort::MemoryInfo("OpenVINO_RT_NPU", OrtArenaAllocator, 0, OrtMemTypeCPUInput);
     if (type_info.GetONNXType() == ONNX_TYPE_TENSOR) {
       auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
       std::vector<int64_t> input_node_dim = tensor_info.GetShape();
@@ -952,7 +952,7 @@ bool OnnxRuntimeTestSession::PopulateGeneratedInputTestData(int32_t seed) {
         }
       }
 
-      auto allocator = Ort::AllocatorWithDefaultOptions();
+      Ort::Allocator allocator(session_, memory_info);
       Ort::Value input_tensor = Ort::Value::CreateTensor(allocator, (const int64_t*)input_node_dim.data(),
                                                          input_node_dim.size(), tensor_info.GetElementType());
       InitializeTensorWithSeed(seed, input_tensor);

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -38,6 +38,8 @@ class OnnxRuntimeTestSession : public TestSession {
   std::mt19937 rand_engine_;
   std::uniform_int_distribution<int> dist_;
   std::vector<std::vector<Ort::Value>> test_inputs_;
+  std::unique_ptr<Ort::Allocator> custom_allocator_;
+  std::vector<Ort::Value> outputs_;
   std::vector<std::string> output_names_;
   // The same size with output_names_.
   // TODO: implement a customized allocator, then we can remove output_names_ to simplify this code


### PR DESCRIPTION
### Description
Avoid memcpy for input and output tensor for OVEP NPU.
Allocating buffer to remote device using the allocator.



