### PR TITLE
Disable driver caching for NPU when epctx enabled for ov version greater then 2024.3

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -182,7 +182,9 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
     device_config.emplace(ov::device::properties("NPU", device_property));
 
     if (global_context_.export_ep_ctx_blob) {
+#if (OPENVINO_VERSION_MAJOR >= 2024) && (OPENVINO_VERSION_MINOR > 3)
       global_context_.ie_core.Get().set_property("NPU", ov::intel_npu::bypass_umd_caching(true));
+#endif
     }
   }
 }


### PR DESCRIPTION
Disable driver caching for NPU when epctx enabled for OV version greater then 2024.3


