### PR TITLE
Modified Create Options to pass config options to execution Provider

### DIFF
--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -50,7 +50,6 @@ struct OpenVINOProviderFactory : IExecutionProviderFactory {
 };
 
 std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {
-
   bool so_disable_cpu_fallback = config_options_.GetConfigOrDefault("session.disable_cpu_ep_fallback", "0") == "1";
   bool so_export_ep_ctx_blob = config_options_.GetConfigOrDefault("ep.context_enable", "0") == "1";
   bool so_epctx_embed_mode = config_options_.GetConfigOrDefault("ep.context_embed_mode", "1") == "1";
@@ -65,7 +64,8 @@ std::unique_ptr<IExecutionProvider> OpenVINOProviderFactory::CreateProvider() {
             auto parent_path = file_path.parent_path();
             if (!parent_path.empty() && !std::filesystem::is_directory(parent_path) &&
                 !std::filesystem::create_directory(parent_path)) {
-              ORT_THROW("[ERROR] [OpenVINO] Failed to create directory : " + file_path.parent_path().generic_string() + " \n");
+              ORT_THROW("[ERROR] [OpenVINO] Failed to create directory : " + \
+                         file_path.parent_path().generic_string() + " \n");
             }
           } else {
             ORT_THROW("[ERROR] [OpenVINO] Invalid ep_ctx_file_path" + cache_dir_ + " \n");
@@ -93,11 +93,11 @@ struct OpenVINO_Provider : Provider {
   void* GetInfo() override { return &g_info; }
 
   std::shared_ptr<IExecutionProviderFactory> CreateExecutionProviderFactory(const void* void_params) override {
-      typedef std::pair<const ProviderOptions*, const ConfigOptions&> buffer_t;
-      const buffer_t* buffer = reinterpret_cast<const buffer_t*>(void_params);
-
-      auto& provider_options_map = *buffer->first;
-      const ConfigOptions& config_options = buffer->second;
+    // Extract the void_params into ProviderOptions and ConfigOptions
+    typedef std::pair<const ProviderOptions*, const ConfigOptions&> ConfigBuffer;
+    const ConfigBuffer* buffer = reinterpret_cast<const ConfigBuffer*>(void_params);
+    auto& provider_options_map = *buffer->first;
+    const ConfigOptions& config_options = buffer->second;
 
     std::string device_type = "";            // [device_type]: Overrides the accelerator hardware type and precision
                                              //   with these values at runtime.
@@ -298,7 +298,7 @@ struct OpenVINO_Provider : Provider {
                                                      context,
                                                      enable_opencl_throttling,
                                                      disable_dynamic_shapes,
-                                                     enable_qdq_optimizer,  
+                                                     enable_qdq_optimizer,
                                                      config_options);
   }
 

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory_creator.h
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory_creator.h
@@ -14,8 +14,7 @@ namespace onnxruntime {
 struct SessionOptions;
 // defined in provider_bridge_ort.cc
 struct OpenVINOProviderFactoryCreator {
-  static std::shared_ptr<IExecutionProviderFactory> Create(ProviderOptions* provider_options_map,
+  static std::shared_ptr<IExecutionProviderFactory> Create(const ProviderOptions* provider_options_map,
                                                            const SessionOptions* session_options);
-  static std::shared_ptr<IExecutionProviderFactory> Create(const OrtOpenVINOProviderOptions* provider_options);
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -578,7 +578,8 @@ struct ProviderHost {
 
   // ConfigOptions
   virtual std::optional<std::string> ConfigOptions__GetConfigEntry(const ConfigOptions* p, const std::string& config_key) = 0;
-  virtual std::string ConfigOptions__GetConfigOrDefault(const ConfigOptions* p, const std::string& config_key, const std::string& default_value) = 0;
+  virtual std::string ConfigOptions__GetConfigOrDefault(const ConfigOptions* p, const std::string& config_key, \
+                                                        const std::string& default_value) = 0;
 
   // OrtRunOptions
   virtual const ConfigOptions& RunOptions__GetConfigOptions(const RunOptions* p) = 0;

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -578,6 +578,7 @@ struct ProviderHost {
 
   // ConfigOptions
   virtual std::optional<std::string> ConfigOptions__GetConfigEntry(const ConfigOptions* p, const std::string& config_key) = 0;
+  virtual std::string ConfigOptions__GetConfigOrDefault(const ConfigOptions* p, const std::string& config_key, const std::string& default_value) = 0;
 
   // OrtRunOptions
   virtual const ConfigOptions& RunOptions__GetConfigOptions(const RunOptions* p) = 0;

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -485,6 +485,10 @@ struct ConfigOptions final {
     return g_host->ConfigOptions__GetConfigEntry(this, config_key);
   }
 
+  std::string GetConfigOrDefault(const std::string& config_key, const std::string& default_value) const {
+    return g_host->ConfigOptions__GetConfigOrDefault(this, config_key, default_value);
+  }
+
   PROVIDER_DISALLOW_ALL(ConfigOptions)
 };
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -41,6 +41,7 @@
 
 #include "core/session/onnxruntime_c_api.h"
 #include "core/common/string_helper.h"
+#include <utility>
 
 #ifdef ENABLE_TRAINING
 #ifdef ENABLE_TRAINING_TORCH_INTEROP
@@ -707,7 +708,8 @@ struct ProviderHostImpl : ProviderHost {
   }
 
   // ConfigOptions (wrapped)
-  std::string ConfigOptions__GetConfigOrDefault(const ConfigOptions* p, const std::string& config_key, const std::string& default_value) override {
+  std::string ConfigOptions__GetConfigOrDefault(const ConfigOptions* p, const std::string& config_key, \
+                                                const std::string& default_value) override {
     return p->GetConfigOrDefault(config_key, default_value);
   }
 
@@ -1814,17 +1816,16 @@ ProviderOptions OrtOpenVINOProviderOptionsToOrtOpenVINOProviderOptionsV2(const O
 
   // Add new provider option below
   ov_options_converted_map["num_streams"] = "1";
-  //ov_options_converted_map["export_ep_ctx_blob"] = "false";
   ov_options_converted_map["model_priority"] = "DEFAULT";
   ov_options_converted_map["enable_qdq_optimizer"] = "false";
   return ov_options_converted_map;
 }
 
-std::shared_ptr<IExecutionProviderFactory> OpenVINOProviderFactoryCreator::Create(const ProviderOptions* provider_options_map,
+std::shared_ptr<IExecutionProviderFactory> OpenVINOProviderFactoryCreator::Create(const ProviderOptions* provider_options_map, \
                                                                                   const SessionOptions* session_options) {
   // Append session options applicable for EP to EP Provider options.
-  std::pair<const ProviderOptions*, const ConfigOptions&> buffer = {provider_options_map, session_options->config_options};
-  const void* obj = reinterpret_cast<const void*>(&buffer);
+  std::pair<const ProviderOptions*, const ConfigOptions&> config_buffer = {provider_options_map, session_options->config_options};
+  const void* obj = reinterpret_cast<const void*>(&config_buffer);
   return s_library_openvino.Get().CreateExecutionProviderFactory(obj);
 }
 
@@ -2078,7 +2079,8 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_MIGraphX, _In
   API_IMPL_END
 }
 
-ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_OpenVINO, _In_ OrtSessionOptions* options, _In_ const OrtOpenVINOProviderOptions* provider_options) {
+ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_OpenVINO, _In_ OrtSessionOptions* options, \
+                   _In_ const OrtOpenVINOProviderOptions* provider_options) {
   API_IMPL_BEGIN
   const onnxruntime::ProviderOptions ov_options_converted_map = onnxruntime::OrtOpenVINOProviderOptionsToOrtOpenVINOProviderOptionsV2(provider_options);
   auto factory = onnxruntime::OpenVINOProviderFactoryCreator::Create(&ov_options_converted_map, &(options->value));

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -99,9 +99,10 @@ std::unique_ptr<IExecutionProvider> MIGraphXExecutionProviderWithOptions(const O
   return nullptr;
 }
 
-std::unique_ptr<IExecutionProvider> OpenVINOExecutionProviderWithOptions(const OrtOpenVINOProviderOptions* params) {
+std::unique_ptr<IExecutionProvider> OpenVINOExecutionProviderWithOptions(const ProviderOptions* params, 
+                                                                         const SessionOptions* session_options) {
 #ifdef USE_OPENVINO
-  return OpenVINOProviderFactoryCreator::Create(params)->CreateProvider();
+  return OpenVINOProviderFactoryCreator::Create(params, session_options)->CreateProvider();
 #else
   ORT_UNUSED_PARAMETER(params);
   return nullptr;

--- a/onnxruntime/test/util/include/default_providers.h
+++ b/onnxruntime/test/util/include/default_providers.h
@@ -49,7 +49,7 @@ std::unique_ptr<IExecutionProvider> TensorrtExecutionProviderWithOptions(const O
 std::unique_ptr<IExecutionProvider> TensorrtExecutionProviderWithOptions(const OrtTensorRTProviderOptionsV2* params);
 std::unique_ptr<IExecutionProvider> DefaultMIGraphXExecutionProvider();
 std::unique_ptr<IExecutionProvider> MIGraphXExecutionProviderWithOptions(const OrtMIGraphXProviderOptions* params);
-std::unique_ptr<IExecutionProvider> OpenVINOExecutionProviderWithOptions(const OrtOpenVINOProviderOptions* params);
+std::unique_ptr<IExecutionProvider> OpenVINOExecutionProviderWithOptions(const ProviderOptions* params, const SessionOptions* session_options = nullptr);
 std::unique_ptr<IExecutionProvider> DefaultOpenVINOExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultNnapiExecutionProvider();
 std::unique_ptr<IExecutionProvider> DefaultVSINPUExecutionProvider();


### PR DESCRIPTION
### Description
Create Passes in a single buffer ProviderOptions and SessionOptions Config to the 
The Factory Creator which stores the reference to config and when createprovider is invoked
same reference is used to get config options


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
This issue isfixing https://microsoft.visualstudio.com/OS/_workitems/edit/53969605

