### PR TITLE
fix: caching lookup to behave correctly when inputs/output mapping

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -23,7 +23,7 @@ namespace openvino_ep {
 
 struct ov_tensor_data_t {
   OVTensorPtr tensor_ptr;
-  bool copy_needed;
+  const void *ort_ptr;
 };
 
 class InferRequestsQueue;
@@ -67,7 +67,7 @@ class BasicBackend : public IBackend {
   OVRemoteContextPtr remote_context_;
 #endif
 
-  using ort_tensor_key_t = std::pair<const void*, const std::string>;
+  using ort_tensor_key_t = const std::string;
   std::map<ort_tensor_key_t, ov_tensor_data_t> ort_ov_tensor_map;
 };
 


### PR DESCRIPTION
### Description

1. changing the emplace to [] that does have a difference, emplace will only create a new entry if it doesn't already exist in the map
2. change the logic of the caching lookup to key off of input/output names instead of ort raw ptrs.
3. changes OV tensor creation for CPU allocated input/output ORT tensors. The CPU allocated input/output tensor path was re-allocating OV tensors based on the ORT input/output tensors. So we'd get 2 copies: ORT input/output tensor -> OV tensor (OVEP) -> NPU Tensor (NPU plugin).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->