### PR TITLE
OVEP: fix tensor regression

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -305,11 +305,13 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
           auto tensor = context.GetInput(subgraph_context_.input_names.at(input_name));
           ort_tensor_key_t ort_tensor_key{input_name};
           auto it = ort_ov_tensor_map.find(ort_tensor_key);
-          if ((it == ort_ov_tensor_map.end()) || (it != ort_ov_tensor_map.end() && (it->second.ort_ptr != tensor.GetTensorRawData()))) {
+          if ((it == ort_ov_tensor_map.end()) ||
+              (it != ort_ov_tensor_map.end() && (it->second.ort_ptr != tensor.GetTensorRawData()))) {
             ov_tensor_data_t ov_tensor_data;
             auto input = graph_input_info.at(input_idx);
             ov_tensor_data.tensor_ptr = std::make_shared<ov::Tensor>(input.get_element_type(), input.get_shape(),
-                                                                     (void*)tensor.GetTensorRawData());
+                                                                     const_cast<void*>(tensor.GetTensorRawData()));
+
             ov_tensor_data.ort_ptr = tensor.GetTensorRawData();
             ort_ov_tensor_map[ort_tensor_key] = ov_tensor_data;
 
@@ -349,12 +351,13 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
                                                    subgraph_context_.output_names);
         ort_tensor_key_t ort_tensor_key{output_name};
         const auto& it = ort_ov_tensor_map.find(ort_tensor_key);
-        if ((it == ort_ov_tensor_map.end()) || (it != ort_ov_tensor_map.end() && (it->second.ort_ptr != tensor.GetTensorRawData()))) {
+        if ((it == ort_ov_tensor_map.end()) ||
+            (it != ort_ov_tensor_map.end() && (it->second.ort_ptr != tensor.GetTensorRawData()))) {
           ov_tensor_data_t ov_tensor_data;
           auto output = graph_output_info.at(output_idx);
           ov_tensor_data.ort_ptr = tensor.GetTensorRawData();
           ov_tensor_data.tensor_ptr = std::make_shared<ov::Tensor>(output.get_element_type(), output.get_shape(),
-                                                                   (void*)tensor.GetTensorRawData());
+                                                                   const_cast<void*>(tensor.GetTensorRawData()));
           ort_ov_tensor_map[ort_tensor_key] = ov_tensor_data;
 
           try {

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -305,7 +305,7 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
           auto tensor = context.GetInput(subgraph_context_.input_names.at(input_name));
           ort_tensor_key_t ort_tensor_key{input_name};
           auto it = ort_ov_tensor_map.find(ort_tensor_key);
-          if (it != ort_ov_tensor_map.end() || it->second.ort_ptr != tensor.GetTensorRawData()) {
+          if ((it == ort_ov_tensor_map.end()) || (it != ort_ov_tensor_map.end() && (it->second.ort_ptr != tensor.GetTensorRawData()))) {
             ov_tensor_data_t ov_tensor_data;
             auto input = graph_input_info.at(input_idx);
             ov_tensor_data.tensor_ptr = std::make_shared<ov::Tensor>(input.get_element_type(), input.get_shape(),
@@ -349,7 +349,7 @@ void BasicBackend::StartAsyncInference(Ort::KernelContext& context, OVInferReque
                                                    subgraph_context_.output_names);
         ort_tensor_key_t ort_tensor_key{output_name};
         const auto& it = ort_ov_tensor_map.find(ort_tensor_key);
-        if (it != ort_ov_tensor_map.end() || it->second.ort_ptr != tensor.GetTensorRawData()) {
+        if ((it == ort_ov_tensor_map.end()) || (it != ort_ov_tensor_map.end() && (it->second.ort_ptr != tensor.GetTensorRawData()))) {
           ov_tensor_data_t ov_tensor_data;
           auto output = graph_output_info.at(output_idx);
           ov_tensor_data.ort_ptr = tensor.GetTensorRawData();

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -23,7 +23,7 @@ namespace openvino_ep {
 
 struct ov_tensor_data_t {
   OVTensorPtr tensor_ptr;
-  bool copy_needed;
+  const void *ort_ptr;
 };
 
 class InferRequestsQueue;
@@ -67,7 +67,7 @@ class BasicBackend : public IBackend {
   OVRemoteContextPtr remote_context_;
 #endif
 
-  using ort_tensor_key_t = std::pair<const void*, const std::string>;
+  using ort_tensor_key_t = const std::string;
   std::map<ort_tensor_key_t, ov_tensor_data_t> ort_ov_tensor_map;
 };
 

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -23,7 +23,7 @@ namespace openvino_ep {
 
 struct ov_tensor_data_t {
   OVTensorPtr tensor_ptr;
-  const void *ort_ptr;
+  const void* ort_ptr;
 };
 
 class InferRequestsQueue;


### PR DESCRIPTION
### Description
1. changing the emplace to [] that does have a difference, emplace will only create a new entry if it doesn't already exist in the map
2. change the logic of the caching lookup to key off of input/output names instead of ort raw ptrs.
3. changes OV tensor creation for CPU allocated input/output ORT tensors. The CPU allocated input/output tensor path was re-allocating OV tensors based on the ORT input/output tensors. So we'd get 2 copies: ORT input/output tensor -> OV tensor (OVEP) -> NPU Tensor (NPU plugin).



