### PR TITLE
update: Using load_config as map

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.cc
+++ b/onnxruntime/core/providers/openvino/backend_utils.cc
@@ -11,7 +11,6 @@
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/openvino/backend_utils.h"
 #include "core/providers/openvino/ov_interface.h"
-#include "nlohmann/json.hpp"
 
 using Exception = ov::Exception;
 
@@ -266,36 +265,6 @@ void printPerformanceCounts(const std::vector<OVProfilingInfo>& performanceMap,
 void printPerformanceCounts(OVInferRequestPtr request, std::ostream& stream, std::string deviceName) {
   auto performanceMap = request->GetNewObj().get_profiling_info();
   printPerformanceCounts(performanceMap, stream, std::move(deviceName));
-}
-
-void LoadConfig(const std::string& filename, std::map<std::string, ov::AnyMap>& config) {
-  std::ifstream input_filestream(filename);
-  if (!input_filestream.is_open()) {
-    ORT_THROW("Can't load config file \"" + filename + "\".");
-  }
-
-  nlohmann::json json_config;
-  try {
-    input_filestream >> json_config;
-  } catch (const OnnxRuntimeException& ex) {
-    ORT_THROW("Can't parse config file \"" + filename + "\".\n" + ex.what());
-  } catch (const std::exception& ex) {
-    throw std::runtime_error("Standard exception for config file \"" + filename + "\".\n" + ex.what());
-  } catch (...) {
-    throw std::runtime_error("Unknown exception for config file \"" + filename + "\".\n");
-  }
-
-  if (json_config.empty()) {
-    ORT_THROW("Empty JSON content passed \"" + filename + "\".");
-  }
-
-  for (auto item = json_config.cbegin(), end = json_config.cend(); item != end; ++item) {
-    const std::string& deviceName = item.key();
-    const auto& item_value = item.value();
-    for (auto option = item_value.cbegin(), item_value_end = item_value.cend(); option != item_value_end; ++option) {
-      config[deviceName][option.key()] = option.value().get<std::string>();
-    }
-  }
 }
 
 }  // namespace backend_utils

--- a/onnxruntime/core/providers/openvino/backend_utils.h
+++ b/onnxruntime/core/providers/openvino/backend_utils.h
@@ -70,8 +70,6 @@ void printPerformanceCounts(const std::vector<OVProfilingInfo>& performanceMap,
 
 void printPerformanceCounts(OVInferRequestPtr request, std::ostream& stream, std::string deviceName);
 
-void LoadConfig(const std::string& filename, std::map<std::string, ov::AnyMap>& config);
-
 }  // namespace backend_utils
 }  // namespace openvino_ep
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -182,8 +182,7 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
   }
 
   if (!global_context_.load_config.empty()) {
-    std::map<std::string, ov::AnyMap> target_config;
-    LoadConfig(global_context_.load_config, target_config);
+    const std::map<std::string, ov::AnyMap>& target_config = global_context_.load_config;
 
     // Parse device types like "AUTO:CPU,GPU" and extract individual devices
     auto parse_individual_devices = [&](const std::string& device_type) -> std::vector<std::string> {

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include <map>
 #include <unordered_map>
 #include <string>
 #include "core/providers/openvino/ov_interface.h"
@@ -27,7 +28,7 @@ struct GlobalContext {
   std::string precision_str;
   std::string model_precision;
   std::string cache_dir;
-  std::string load_config;
+  std::map<std::string, ov::AnyMap> load_config;
   std::string model_priority = "DEFAULT";
   int num_streams;
   std::vector<bool> deviceAvailableList = {true, true, true, true, true, true, true, true};

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -80,7 +80,7 @@ struct OpenVINOExecutionProviderInfo {
   std::string device_type_{""};
   std::string precision_{""};
   size_t num_of_threads_{0};
-  std::string load_config_{""};
+  std::map<std::string, ov::AnyMap> load_config_{};
   std::string cache_dir_{""};
   std::string model_priority_{""};
   int num_streams_{1};
@@ -96,7 +96,8 @@ struct OpenVINOExecutionProviderInfo {
 
   explicit OpenVINOExecutionProviderInfo(const std::string& dev_type, const std::string& precision,
                                          size_t num_of_threads,
-                                         const std::string& load_config, const std::string& cache_dir,
+                                         const std::map<std::string, ov::AnyMap>& load_config,
+                                         const std::string& cache_dir,
                                          const std::string& model_priority, int num_streams,
                                          void* context, bool enable_opencl_throttling,
                                          bool disable_dynamic_shapes, bool export_ep_ctx_blob,


### PR DESCRIPTION
### Description
This PR enables a feature for loading custom JSON OV config **Map** during runtime which sets OV parameters.

Usage - 

`onnxruntime_perf_test.exe -e openvino -m times -r 1 -i "device_type|NPU load_config|npu_config.json” model.onnx`

where **npu_config.json** is given below -

**npu_config.json** 

<img width="788" alt="image" src="https://github.com/user-attachments/assets/9c25ff6a-a679-4a96-9659-87af5f74e0ce">


This PR addresses the ticket request -
https://jira.devtools.intel.com/browse/EISW-138355


