### PR TITLE
GPU.1 and GPU.0 options added

### DIFF
--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -58,7 +58,7 @@ static std::vector<std::string> parseDevices(const std::string& device_string,
     print_build_options();
     ORT_THROW("Invalid device string: " + device_string);
   }
-  std::set<std::string> dev_options = {"CPU", "GPU", "NPU"};
+  std::set<std::string> dev_options = {"CPU", "GPU", "NPU", "GPU.1", "GPU.0"};
 
   for (auto& device : available_devices) {
     if (dev_options.find(device) == dev_options.end()) {

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -58,7 +58,7 @@ static std::vector<std::string> parseDevices(const std::string& device_string,
     print_build_options();
     ORT_THROW("Invalid device string: " + device_string);
   }
-  std::set<std::string> dev_options = {"CPU", "GPU", "NPU", "GPU.1", "GPU.0"};
+  std::set<std::string> dev_options = {"CPU", "GPU", "NPU", "GPU.0", "GPU.1"};
 
   for (auto& device : available_devices) {
     if (dev_options.find(device) == dev_options.end()) {


### PR DESCRIPTION
Added 'GPU.1' and 'GPU.0' options to device options to allow the option of 'AUTO/MULTI/HETERO: GPU.0/1, CPU' type inferencing. 


