### PR TITLE
feat: Enable NPUW Support

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -48,6 +48,16 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
   // Set the inference_num_threads property of the CPU
   SetNumThreads(device_config);
 
+  auto npuw_status =
+      std::any_of(device_config.begin(), device_config.end(), [&](const std::pair<std::string, ov::Any>& pair) {
+        return (pair.first.find("NPU_USE_NPUW") != std::string::npos) && (pair.second.is<std::string>()) &&
+               (pair.second.as<std::string>() == "YES");
+      });
+
+  if (npuw_status) {
+    LOGS_DEFAULT(INFO) << log_tag << "NPUW Enabled during compilation";
+  }
+
   try {
     std::string dev_prec = global_context.device_type + "_" + global_context_.precision_str;
 
@@ -184,6 +194,33 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
   if (!global_context_.load_config.empty()) {
     const std::map<std::string, ov::AnyMap>& target_config = global_context_.load_config;
 
+    if (global_context_.device_type.find("NPU") != std::string::npos) {
+      auto npuw_config = target_config.at("NPU");
+
+      // Check if "NPU_USE_NPUW" exists and is set to "YES"
+      auto npu_use_npuw_it = npuw_config.find("NPU_USE_NPUW");
+      if (npu_use_npuw_it != npuw_config.end() &&
+          npu_use_npuw_it->second.is<std::string>() &&
+          npu_use_npuw_it->second.as<std::string>() == "YES") {
+        // Only add NPUW-related keys if NPU_USE_NPUW is "YES"
+        for (const auto& [key, value] : npuw_config) {
+          if (key.find("NPUW") != std::string::npos) {
+            if (!value.is<std::string>()) {
+              LOGS_DEFAULT(ERROR) << "Invalid value type for key: " << key;
+              continue;
+            }
+            device_config[key] = value;
+          }
+        }
+      } else {
+        // Check if there are any "NPUW" keys and log a warning
+        if (std::any_of(npuw_config.begin(), npuw_config.end(),
+                        [&](const auto& pair) { return pair.first.find("NPUW") != std::string::npos; })) {
+          LOGS_DEFAULT(WARNING) << "Skipping NPUW-related configurations as NPU_USE_NPUW is not set to 'YES'.";
+        }
+      }
+    }
+
     // Parse device types like "AUTO:CPU,GPU" and extract individual devices
     auto parse_individual_devices = [&](const std::string& device_type) -> std::vector<std::string> {
       std::vector<std::string> devices;
@@ -213,6 +250,9 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
     auto set_target_properties = [&](const std::string& device, const ov::AnyMap& config_options,
                                      const std::vector<ov::PropertyName>& supported_properties) {
       for (const auto& [key, value] : config_options) {
+        if (key.find("NPUW") != std::string::npos) {
+          continue;
+        }
         if (is_supported_and_mutable(key, supported_properties)) {
           global_context_.ie_core.Get().set_property(device, ov::AnyMap{{key, value}});
         } else {


### PR DESCRIPTION
### Description
This PR enables NPUW support in OVEP.

The NPUW comes pre baked with OV Toolkit available in open source forums. If you seek to validate the NPUW::INFO logs explicitly during runtime, you need a custom built OV Toolkit, with recipe given below and must set below flag.

Flag - `set OPENVINO_NPUW_LOG=INFO`

Custom OV Toolkit Build Recipe with NPUW Debug Logs - https://wiki.ith.intel.com/display/VPUWIKI/NPUW#NPUW-Building

This feature can be accessed with `load_config` provider options accepting below sample JSON file and schema -



**npuw_config.json**
```
{
    "NPU" : {
        "NPU_USE_NPUW" : "YES",
        "NPU_COMPILATION_MODE_PARAMS" :
            "compute-layers-with-higher-precision=Sqrt,Power,ReduceSum",
        "NPUW_PARALLEL_COMPILE" : "NO",
        "NPUW_FOLD" : "YES",
        "NPUW_DQ" : "YES",
        "NPUW_FUNCALL_FOR_ALL" : "YES",
        "NPUW_WEIGHTS_BANK" : "shared",
        "NPUW_FUNCALL_ASYNC" : "YES",
        "NPUW_SLICE_OUT" : "YES",
        "NPU_TILES" : "4"
        
    }
}
```

**MANDATORY Config in JSON config MUST include  `"NPU_USE_NPUW" : "YES"` to enable NPUW Compilation to begin with, while other NPUW related properties/options are optional and must be used in combination with `"NPU_USE_NPUW" : "YES"` always.** 

For more info on NPUW Options refer URL : https://wiki.ith.intel.com/display/VPUWIKI/Options

Using **onnxruntime_perf_test** app, you can run it as below -

`onnxruntime\build\Windows\RelWithDebInfo\RelWithDebInfo\onnxruntime_perf_test.exe -v  -I -e openvino -m times -r 10 -i "device_type|NPU load_config|path\to\npuw_cfg.json" model.onnx`



