### PR TITLE
No need for get_runtime_model in Import Network

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -81,7 +81,6 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
                                                            device_config,
                                                            global_context_.ep_context_embed_mode,
                                                            subgraph_context_.subgraph_name);
-        ie_cnn_network_ = exe_network_.Get().get_runtime_model();
       } else if (global_context_.export_ep_ctx_blob &&
                  hw_target.find("NPU") != std::string::npos &&
                  !global_context_.has_external_weights) {


### PR DESCRIPTION
### Description
This change is done to remove dead code which is causing an exception



### Motivation and Context
This change was required because get_runtime_model was no longer implemented in OpenVINO
- If it fixes an open issue, please link to the issue here. -->


