### PR TITLE
Run subgraphs with model inputs.

### DIFF
--- a/.github/workflows/internal_ci.yml
+++ b/.github/workflows/internal_ci.yml
@@ -1,0 +1,34 @@
+name : Internal CI
+
+on:
+  pull_request:
+    branches:
+      - '**'  # Triggers on a PR to any Branch
+
+jobs:
+  build:
+
+    runs-on: [self-hosted, Linux, X64]   # Runs on a Lunar lake
+    env:
+      BUILD_SOURCESDIRECTORY: ${{ github.workspace }}
+      BUILD_BINARIESDIRECTORY: ${{ github.workspace }}/build
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}  # checkout the pr branch
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+       python-version: '3.10'
+
+    - name: Create build directory
+      run: |
+         mkdir -p ${{ env.BUILD_BINARIESDIRECTORY }}
+         chmod -R 777 ${{ env.BUILD_BINARIESDIRECTORY }}
+
+    - name: Running Internal CI   # Trigger Internal CI on the pr branch
+      run: |
+        cd tools/ci_build/github/linux/
+        dir
+        ./run_dockerbuild.sh -o ubuntu22.04 -p 3.10 -d openvino -v 2024.5.0 -x "--config Release --use_openvino CPU --build_wheel --build_shared_lib --parallel "

--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -79,9 +79,6 @@ BackendManager::BackendManager(const GlobalContext& global_context,
   if (ModelHasSymbolicInputDims(subgraph)) {
     subgraph_context_.has_dynamic_input_shape = true;
     LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has symbolic input dims";
-    ORT_ENFORCE(!global_context_.enable_qdq_optimizer,
-                "QDQ stripping should not be enabled for models with dynamic input shapes. "
-                "Set enable_qdq_optimizer to False");
     if ((GetGlobalContext().device_type.find("CPU") != std::string::npos ||
          GetGlobalContext().device_type.find("GPU") != std::string::npos) &&
         !GetGlobalContext().disable_dynamic_shapes) {

--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -166,16 +166,6 @@ std::vector<std::unique_ptr<ComputeCapability>> GetCapability::Execute() {
       // Omitting zero dim subgraphs
       for (auto index : this_cluster) {
         const Node* node = graph_viewer_.GetNode(index);
-        if (data_ops_->DoNotOmitSubGraph(node->OpType())) {
-          for (const auto& input : node->InputDefs()) {
-            const auto& input_name = input->Name();
-            auto it = find(cluster_graph_inputs.begin(), cluster_graph_inputs.end(), input_name);
-            if (it != cluster_graph_inputs.end()) {
-              omit_subgraph = true;
-              break;
-            }
-          }
-        }
 
         if (node->OpType() == "Conv" || node->OpType() == "Identity") {
           const auto& output_name = node->OutputDefs()[0]->Name();


### PR DESCRIPTION
Description
Run subgraphs with model inputs. #527 on ovep-develop-ptl-1.1

Motivation and Context
Subgraphs with model inputs were omitted for an unknown reason. Including them improves performance for key use cases.
