### PR TITLE
Weight as input model creation and external data initializer's metadata extraction for weight sharing

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -362,7 +362,7 @@ BackendManager::GetModelProtoFromFusedNode(const onnxruntime::Node& fused_node,
       IsQDQGraph(subgraph)) {
     LOGS_DEFAULT(INFO) << "[OpenVINO-EP] QDQ optimization pass status: 1";
     std::unique_ptr<onnxruntime::Model> model;
-    Status status = CreateModelWithStrippedQDQNodes(subgraph, logger, model);
+    Status status = CreateModelWithStrippedQDQNodes(subgraph, logger, session_context_.enable_ovep_weight_sharing, model);
     auto model_proto = model->ToProto();
     model_proto->set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
     print_model_proto_duration();

--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -720,6 +720,7 @@ bool dumpMetaDataMapToBinary(const std::unordered_map<std::string, std::vector<s
 // Creates a new model without the DQ/Q operators in the src graph.
 Status CreateModelWithStrippedQDQNodes(const GraphViewer& src_graph,
                                        const logging::Logger& logger,
+                                       bool enable_ovep_weight_sharing,
                                        /*out*/ std::unique_ptr<onnxruntime::Model>& model) {
   // NOTE: This function is a re-implementation of GraphViewerToProto() in core/graph/graph_proto_serializer.cc
   // with the following differences:

--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -668,6 +668,55 @@ static void AddInitializerAsInput(onnxruntime::Graph& dst_graph,
     }
 }
 
+bool writeString(std::ofstream& outfile, const std::string& str) {
+    size_t size = str.size();
+    outfile.write(reinterpret_cast<const char*>(&size), sizeof(size));
+    if (!outfile.good()) return false;
+
+    outfile.write(str.c_str(), size);
+    return outfile.good();
+}
+
+bool writeStringVector(std::ofstream& outfile, const std::vector<std::string>& vec) {
+    size_t size = vec.size();
+    outfile.write(reinterpret_cast<const char*>(&size), sizeof(size));
+    if (!outfile.good()) return false;
+
+    for (const auto& str : vec) {
+        if (!writeString(outfile, str)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Main function to dump the map to a binary file
+bool dumpMetaDataMapToBinary(const std::unordered_map<std::string, std::vector<std::string>>& map, const std::string& filename) {
+
+  std::ofstream outfile(filename, std::ios::binary);
+  if (!outfile.is_open()) {
+      ORT_THROW("Error: Could not open file for writing metadata.");
+      return false;
+  }
+
+  // Write the size of the map
+  size_t map_size = map.size();
+  outfile.write(reinterpret_cast<const char*>(&map_size), sizeof(map_size));
+  if (!outfile.good()) {
+      ORT_THROW("Error: Failed to write map size.");
+      return false;
+  }
+
+  // Write each key-value pair
+  for (const auto& pair : map) {
+      if (!writeString(outfile, pair.first) || !writeStringVector(outfile, pair.second)) {
+          ORT_THROW("Error: Failed to write map data.");
+          return false;
+      }
+  }
+
+  return true;
+}
 
 // Creates a new model without the DQ/Q operators in the src graph.
 Status CreateModelWithStrippedQDQNodes(const GraphViewer& src_graph,
@@ -782,14 +831,40 @@ Status CreateModelWithStrippedQDQNodes(const GraphViewer& src_graph,
   }
   std::sort(const_inits.begin(), const_inits.end());
 
+  // initialize map for creating metadata for initilizers with external weights
+  std::unordered_map<std::string, std::vector<std::string>> metadata_map;
+
+  // metadata structure: initializer_name as key
+  // and [location, offset, length] as value
+
   for (auto& it : const_inits) {
       const auto* initializer_tensor = initializers.at(it);
 
       // Check if the initializer has external data
       if (initializer_tensor->has_data_location() &&
           initializer_tensor->data_location() == ONNX_NAMESPACE::TensorProto_DataLocation_EXTERNAL) {
-          // Add initializer with external data as input
-          AddInitializerAsInput(dst_graph, src_graph, it);
+            if (enable_ovep_weight_sharing) {
+
+              // Cast away const to access mutable_external_data
+              struct ONNX_NAMESPACE::TensorProto* non_const_initializer_tensor = const_cast<ONNX_NAMESPACE::TensorProto*>(initializer_tensor);
+
+              // get meta data about the initilizers with external data
+              struct ONNX_NAMESPACE::StringStringEntryProtos* external_data =  non_const_initializer_tensor->mutable_external_data();
+
+              std::vector<std::string> init_info;
+              // init_info structure: [location, offset, length]
+
+              for (int i = 0 ; i < external_data->size() ; i++) {
+                init_info.push_back(*external_data->at(i).mutable_value());
+              }
+
+              metadata_map.emplace(initializer_tensor->name(), init_info);
+              // Add initializer with external data as input
+              AddInitializerAsInput(dst_graph, src_graph, it);
+            } else if (initializers_to_keep.count(it)) {
+              dst_graph.AddInitializedTensor(*initializer_tensor);
+            }
+
       } else {
           // Add as an initialized tensor if it does not have external data
           if (initializers_to_keep.count(it)) {
@@ -810,12 +885,30 @@ Status CreateModelWithStrippedQDQNodes(const GraphViewer& src_graph,
 
           if (src_graph.IsConstantInitializer(input->Name(), true)) {
               const auto* initializer_tensor = src_graph.GetConstantInitializer(input->Name(), true);
-
               // Check if the initializer has external data
               if (initializer_tensor->has_data_location() &&
                   initializer_tensor->data_location() == ONNX_NAMESPACE::TensorProto_DataLocation_EXTERNAL) {
-                  // Add initializer as input if it has external data
-                  AddInitializerAsInput(dst_graph, src_graph, input->Name());
+                    if (enable_ovep_weight_sharing) {
+
+                      // Cast away const to access mutable_external_data
+                      struct ONNX_NAMESPACE::TensorProto* non_const_initializer_tensor = const_cast<ONNX_NAMESPACE::TensorProto*>(initializer_tensor);
+
+                      // get meta data about the initilizers with external data
+                      struct ONNX_NAMESPACE::StringStringEntryProtos* external_data =  non_const_initializer_tensor->mutable_external_data();
+
+                      std::vector<std::string> init_info;
+                      for (int i = 0 ; i < external_data->size() ; i++) {
+                        init_info.push_back(*external_data->at(i).mutable_value());
+                      }
+
+                      metadata_map.emplace(initializer_tensor->name(), init_info);
+
+                      // Add initializer as input if it has external data
+                      AddInitializerAsInput(dst_graph, src_graph, input->Name());
+                    } else if (initializers_to_keep.count(input->Name())) {
+                      dst_graph.AddInitializedTensor(*initializer_tensor);
+                    }
+
               } else {
                   // Add as an initialized tensor if it does not have external data
                   if (initializers_to_keep.count(input->Name())) {
@@ -827,6 +920,15 @@ Status CreateModelWithStrippedQDQNodes(const GraphViewer& src_graph,
           }
       }
   }
+
+  if (enable_ovep_weight_sharing) {
+    // creating bin file of metadata_map and dumping the bin file
+    dumpMetaDataMapToBinary(metadata_map, "metadata.bin");
+    LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Metadata for external initializer dumped.";
+  } else{
+    ORT_THROW("Unable to write metadata to file.");
+  }
+
   accumulated_inputs.insert(accumulated_inputs.end(), dst_graph_inputs.begin(), dst_graph_inputs.end());
 
   // Set all inputs (original inputs amnd initializers as inputs) of the destination Graph

--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -920,13 +920,13 @@ Status CreateModelWithStrippedQDQNodes(const GraphViewer& src_graph,
           }
       }
   }
-
   if (enable_ovep_weight_sharing) {
     // creating bin file of metadata_map and dumping the bin file
-    dumpMetaDataMapToBinary(metadata_map, "metadata.bin");
-    LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Metadata for external initializer dumped.";
-  } else{
-    ORT_THROW("Unable to write metadata to file.");
+    if (dumpMetaDataMapToBinary(metadata_map, "metadata.bin")) {
+      LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Metadata for external initializer dumped.";
+    } else {
+      ORT_THROW("Error: Unable to write metadat to file.");
+    }
   }
 
   accumulated_inputs.insert(accumulated_inputs.end(), dst_graph_inputs.begin(), dst_graph_inputs.end());

--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.h
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.h
@@ -12,6 +12,7 @@ namespace openvino_ep {
 // Creates a new model without the DQ/Q operators in the src graph as per pre-defined rulesets
 Status CreateModelWithStrippedQDQNodes(const GraphViewer& src_graph,
                                        const logging::Logger& logger,
+                                       bool enable_ovep_weight_sharing,
                                        /*out*/ std::unique_ptr<onnxruntime::Model>& model);
 
 }  // namespace openvino_ep


### PR DESCRIPTION
### Description

This PR introduces creating weight as input model. 
Specifically, it modifies the handling of initializers with external data, attaching them as graph inputs. 
Additionally, the PR introduces a mechanism for managing metadata of external data initializer.

- Metadata is maintained in a map, where:
      -         Key: Name of the initializer.
      -         Value: A vector containing [location, offset, length].


- How to use this in perf test

       onnxruntime_perf_test.exe -e openvino -i "device_type|NPU enable_qdq_optimizer|true" -C "ep.share_ep_contexts|1" -m times -r 1 -o 0 -v  -I <path to onnx model>


Note: Probably we may need to store metadata in memory for whole session, because we will need metadata in the inference part. Planning to do it if there is any specific need. Additionally, the metadata file naming convention will be updated in future PRs to align with any upcoming requirements or enhancements.