### PR TITLE
create ov tensor from external data and metadata

### DIFF
--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -920,7 +920,6 @@ Status CreateModelWithStrippedQDQNodes(const GraphViewer& src_graph,
   };
   // metadata structure: initializer_name as key
   // and [location, offset, length] as value
-  std::cout << typeid(metadata).name();
   for (auto& it : const_inits) {
     const auto* initializer_tensor = initializers.at(it);
 


### PR DESCRIPTION
### Description
This PR introduces functionality to create an OpenVINO  tensor directly from metadata and external data. 
The tensor will be utilized for inference in subsequent operations.

### Next steps
1. Setting up the created OV tensors for inference
2. Improve metadata storage which will also include 
    dimension
    dataType 


