### PR TITLE
Restrict NPU allocator to case when NPU is selected.

### DIFF
--- a/cmake/onnxruntime_providers_openvino.cmake
+++ b/cmake/onnxruntime_providers_openvino.cmake
@@ -17,7 +17,7 @@
     message(FATAL_ERROR "OpenVINO 2024.5 and newer are supported. Please, use latest OpenVINO release")
   endif()
 
-  if(OpenVINO_VERSION VERSION_GREATER_EQUAL 2024.4)
+  if(onnxruntime_USE_OPENVINO_NPU AND (OpenVINO_VERSION VERSION_GREATER_EQUAL 2024.4))
     add_definitions(-DUSE_OVEP_NPU_MEMORY=1)
   endif()
 


### PR DESCRIPTION
### Description
OVEP is currently always reporting the NPU allocator when OV is >= 2024.4. This change restricts reporting the NPU allocator only when NPU is selected in the configuration

### Motivation and Context
Adds a second guard against exposing the allocator in the wrong scenario.


