### PR TITLE
Epctx node base path fix and lint fix

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.cc
+++ b/onnxruntime/core/providers/openvino/backend_utils.cc
@@ -92,13 +92,13 @@ std::istream& operator>>(std::istream& stream, SharedContext::SharedWeights::Met
 
       size_t safe_num_dimensions = num_dimensions;
 
-      if(num_dimensions == 0 || safe_num_dimensions > MAX_SAFE_DIMENSIONS) {
-         ORT_THROW("Invalid number of dimensions provided.");
+      if (num_dimensions == 0 || safe_num_dimensions > MAX_SAFE_DIMENSIONS) {
+        ORT_THROW("Invalid number of dimensions provided.");
       }
       try {
-          value.dimensions.resize(safe_num_dimensions);
+        value.dimensions.resize(safe_num_dimensions);
       } catch (const std::bad_alloc&) {
-          ORT_THROW("Error: Memory allocation failed while resizing dimensions.");
+        ORT_THROW("Error: Memory allocation failed while resizing dimensions.");
       }
 
       for (auto& dim : value.dimensions) {

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.h
@@ -31,7 +31,7 @@ class EPCtxHandler {
                                const std::string& graph_name,
                                const bool embed_mode,
                                std::string&& model_blob_str) const;
-  std::unique_ptr<std::istream> GetModelBlobStream(const GraphViewer& graph_viewer) const;
+  std::unique_ptr<std::istream> GetModelBlobStream(const std::filesystem::path& so_context_file_path, const GraphViewer& graph_viewer) const;
   InlinedVector<const Node*> GetEPCtxNodes() const;
 
  private:

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -22,9 +22,9 @@ void ParseConfigOptions(ProviderInfo& pi, const ConfigOptions& config_options) {
   pi.so_context_file_path = config_options.GetConfigOrDefault(kOrtSessionOptionEpContextFilePath, "");
 }
 
-void* ParseUint64(const ProviderOptions& provider_options, [[maybe_unused]] std::string option_name) {
-  if (provider_options.contains("context")) {
-    uint64_t number = std::strtoull(provider_options.at("context").data(), nullptr, 16);
+void* ParseUint64(const ProviderOptions& provider_options, std::string option_name) {
+  if (provider_options.contains(option_name)) {
+    uint64_t number = std::strtoull(provider_options.at(option_name).data(), nullptr, 16);
     return reinterpret_cast<void*>(number);
   } else {
     return nullptr;


### PR DESCRIPTION
Description
When creating EpContext nodes any external dependencies such as blobs are located relative to the model that contains the node. This PR fixes an issue where external dependencies were not found if session was created with a model passed from memory. In that case since the model name is empty the EP should use the session option ep.context_file_path to locate the base path.

Motivation and Context
Fix internal bug.

HAFP-2993


