### PR TITLE
Resolve error messages on exit when using python bindings

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.cc
+++ b/onnxruntime/core/providers/openvino/backend_utils.cc
@@ -144,7 +144,7 @@ CreateOVModel(const std::string model,
     std::cout << "CreateNgraphFunc" << std::endl;
   }
   try {
-    auto ov_model = OVCore::ReadModel(model, session_context.onnx_model_path_name.string());
+    auto ov_model = OVCore::Get()->ReadModel(model, session_context.onnx_model_path_name.string());
 
     // Check for Constant Folding
     if ((session_context.device_type != "NPU") && !session_context.is_wholly_supported_graph) {
@@ -412,7 +412,7 @@ void CreateOVTensors(const std::string& device_name,
     // Create OpenVINO Tensor
     if (device_name == "NPU") {
       // Use remote tensors
-      auto npu_context = OVCore::Get().get_default_context("NPU").as<ov::intel_npu::level_zero::ZeroContext>();
+      auto npu_context = OVCore::Get()->core.get_default_context("NPU").as<ov::intel_npu::level_zero::ZeroContext>();
       auto&& remote_tensor = npu_context.create_l0_host_tensor(ov_elementType, value.dimensions, ov::intel_npu::TensorType::INPUT);
 
       // Copy data to remote tensor

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -62,9 +62,9 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
     // Pre-requisite is provider_option "context" must be set
 #if defined(IO_BUFFER_ENABLED)
     cl_context ctx = static_cast<cl_context>(session_context_.context);
-    remote_context_ = new ov::intel_gpu::ocl::ClContext(OVCore::Get(), ctx);
+    remote_context_ = new ov::intel_gpu::ocl::ClContext(OVCore::Get()->core, ctx);
     if (subgraph_context_.is_ep_ctx_graph) {
-      exe_network_ = OVCore::ImportModel(*model_stream,
+      exe_network_ = OVCore::Get()->ImportModel(*model_stream,
                                          remote_context_,
                                          subgraph_context_.subgraph_name);
       model_stream.reset();  // Delete stream after it is no longer needed
@@ -78,7 +78,7 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
         ov_model = CreateOVModel(model, session_context_, const_outputs_map_);
       }
       LOGS_DEFAULT(INFO) << log_tag << "IO Buffering Enabled";
-      exe_network_ = OVCore::CompileModel(
+      exe_network_ = OVCore::Get()->CompileModel(
           ov_model, remote_context_, subgraph_context_.subgraph_name);
     }
 #else  // !IO_BUFFER_ENABLED
@@ -88,7 +88,7 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
     if (subgraph_context_.is_ep_ctx_graph) {
       // If the blob is held in an EPContext node, then skip FE+Compile
       // and directly move on to creating a backend with the executable blob
-      exe_network_ = OVCore::ImportModel(*model_stream,
+      exe_network_ = OVCore::Get()->ImportModel(*model_stream,
                                          hw_target,
                                          device_config,
                                          subgraph_context_.subgraph_name);
@@ -102,7 +102,7 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
       // Inputs with static dimenstions
       // Not enabled for models with external weights and when ep context is set.
       const std::string model = model_proto->SerializeAsString();
-      exe_network_ = OVCore::CompileModel(model,
+      exe_network_ = OVCore::Get()->CompileModel(model,
                                           hw_target,
                                           device_config,
                                           subgraph_context_.subgraph_name);
@@ -116,7 +116,7 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
         }
         ov_model = CreateOVModel(std::move(model), session_context_, const_outputs_map_);
       }
-      exe_network_ = OVCore::CompileModel(
+      exe_network_ = OVCore::Get()->CompileModel(
           ov_model, hw_target, device_config, subgraph_context_.subgraph_name);
     }
 #endif
@@ -196,7 +196,7 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
     device_config.emplace(ov::device::properties("NPU", device_property));
 #if (((OPENVINO_VERSION_MAJOR == 2024) && (OPENVINO_VERSION_MINOR > 3)) || (OPENVINO_VERSION_MAJOR > 2024))
     if (session_context_.so_context_enable) {
-      OVCore::Get().set_property("NPU", ov::intel_npu::bypass_umd_caching(true));
+      OVCore::Get()->core.set_property("NPU", ov::intel_npu::bypass_umd_caching(true));
     }
 #endif
   }
@@ -264,7 +264,7 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
           continue;
         }
         if (is_supported_and_mutable(key, supported_properties)) {
-          OVCore::Get().set_property(device, ov::AnyMap{{key, value}});
+          OVCore::Get()->core.set_property(device, ov::AnyMap{{key, value}});
         } else {
           LOGS_DEFAULT(WARNING) << "WARNING: Property \"" << key
                                 << "\" is either unsupported in current OpenVINO version"
@@ -284,14 +284,14 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
       for (const std::string& device : individual_devices) {
         if (target_config.count(device)) {
           // Get supported properties for each individual device
-          auto device_properties = OVCore::Get().get_property(device, ov::supported_properties);
+          auto device_properties = OVCore::Get()->core.get_property(device, ov::supported_properties);
           // Set properties for the device
           set_target_properties(device, target_config.at(device), device_properties);
         }
       }
     } else {
       if (target_config.count(session_context_.device_type)) {
-        auto supported_properties = OVCore::Get().get_property(session_context_.device_type,
+        auto supported_properties = OVCore::Get()->core.get_property(session_context_.device_type,
                                                                ov::supported_properties);
         set_target_properties(session_context_.device_type,
                               target_config.at(session_context_.device_type), supported_properties);
@@ -306,7 +306,7 @@ void BasicBackend::EnableCaching() {
 
   if (!session_context_.cache_dir.empty() && !session_context_.so_context_enable) {
     LOGS_DEFAULT(INFO) << log_tag << "Enables Caching";
-    OVCore::SetCache(session_context_.cache_dir.string());
+    OVCore::Get()->SetCache(session_context_.cache_dir.string());
   }
 }
 
@@ -337,7 +337,7 @@ void BasicBackend::EnableStreams() {
     }
     // Do nothing
   } else {
-    OVCore::SetStreams(session_context_.device_type, session_context_.num_streams);
+    OVCore::Get()->SetStreams(session_context_.device_type, session_context_.num_streams);
   }
 }
 

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -17,7 +17,12 @@ namespace openvino_ep {
 
 namespace fs = std::filesystem;
 
-struct SharedContext {
+class SharedContext : public WeakSingleton<SharedContext> {
+  // Keep the core alive as long as the shared SharedContext are alive.
+  std::shared_ptr<OVCore> OVCore_;
+
+ public:
+  SharedContext() : OVCore_(OVCore::Get()) {}
   struct SharedWeights {
     struct Metadata {
       struct Key {

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -52,63 +52,7 @@ static std::vector<std::string> parseDevices(const std::string& device_string,
 }
 #endif
 
-// Parking this code here for now before it's moved to the factory
-void AdjustProviderInfo(ProviderInfo& info) {
-  std::set<std::string> ov_supported_device_types = {"CPU", "GPU",
-                                                     "GPU.0", "GPU.1", "NPU"};
-
-  std::vector<std::string> available_devices = OVCore::GetAvailableDevices();
-
-  for (auto& device : available_devices) {
-    if (ov_supported_device_types.find(device) == ov_supported_device_types.end()) {
-      ov_supported_device_types.emplace(device);
-    }
-  }
-
-  if (info.device_type == "") {
-    LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
-                       << "No runtime device selection option provided.";
-#if defined OPENVINO_CONFIG_CPU
-    info.device_type = "CPU";
-    info.precision = "FP32";
-#elif defined OPENVINO_CONFIG_GPU
-    info.device_type = "GPU";
-    info.precision = "FP16";
-#elif defined OPENVINO_CONFIG_NPU
-    info.device_type = "NPU";
-    info.precision = "FP16";
-#elif defined OPENVINO_CONFIG_HETERO || defined OPENVINO_CONFIG_MULTI || defined OPENVINO_CONFIG_AUTO
-#ifdef DEVICE_NAME
-#define DEVICE DEVICE_NAME
-#endif
-    dev_type = DEVICE;
-
-    if (info.device_type.find("HETERO") == 0 || info.device_type.find("MULTI") == 0 || info.device_type.find("AUTO") == 0) {
-      std::vector<std::string> devices = parseDevices(info.device_type, available_devices);
-      info.precision = "FP16";
-      if (devices[0] == "CPU") {
-        info.precision = "FP32";
-      }
-      info.device_type = std::move(dev_type);
-    }
-#endif
-  } else if (ov_supported_device_types.find(info.device_type) != ov_supported_device_types.end()) {
-    info.device_type = std::move(info.device_type);
-  }
-#if defined OPENVINO_CONFIG_HETERO || defined OPENVINO_CONFIG_MULTI || defined OPENVINO_CONFIG_AUTO
-  else if (info.device_type.find("HETERO") == 0 || info.device_type.find("MULTI") == 0 || info.device_type.find("AUTO") == 0) {
-    std::ignore = parseDevices(info.device_type, available_devices);
-    info.device_type = std::move(info.device_type);
-  }
-#endif
-  else {
-    ORT_THROW("Invalid device string: " + info.device_type);
-  }
-  LOGS_DEFAULT(INFO) << "[OpenVINO-EP]"
-                     << "Choosing Device: " << info.device_type << " , Precision: " << info.precision;
-}
-
-OpenVINOExecutionProvider::OpenVINOExecutionProvider(const ProviderInfo& info, SharedContext& shared_context)
+OpenVINOExecutionProvider::OpenVINOExecutionProvider(const ProviderInfo& info, std::shared_ptr<SharedContext> shared_context)
     : IExecutionProvider{onnxruntime::kOpenVINOExecutionProvider},
       session_context_(info),
       shared_context_{shared_context},
@@ -119,7 +63,7 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const ProviderInfo& info, S
   // using OVCore capability GetAvailableDevices to fetch list of devices plugged in
   if (info.cache_dir.empty()) {
     bool device_found = false;
-    std::vector<std::string> available_devices = OVCore::GetAvailableDevices();
+    std::vector<std::string> available_devices = OVCore::Get()->GetAvailableDevices();
     // Checking for device_type configuration
     if (info.device_type != "") {
       if (info.device_type.find("HETERO") != std::string::npos ||
@@ -194,7 +138,7 @@ common::Status OpenVINOExecutionProvider::Compile(
   }
 
   // Temporary code to read metadata before it moves to the .bin
-  auto& metadata = shared_context_.shared_weights.metadata;
+  auto& metadata = shared_context_->shared_weights.metadata;
   if (session_context_.so_share_ep_contexts && metadata.empty()) {
     // Metadata is always read from model location, this could be a source or epctx model
     fs::path metadata_filename = session_context_.onnx_model_path_name.parent_path() / "metadata.bin";
@@ -222,7 +166,7 @@ common::Status OpenVINOExecutionProvider::Compile(
     // For original model, check if the user wants to export a model with pre-compiled blob
 
     auto& backend_manager = backend_managers_.emplace_back(session_context_,
-                                                           shared_context_,
+                                                           *shared_context_,
                                                            fused_node,
                                                            graph_body_viewer,
                                                            logger,
@@ -291,7 +235,7 @@ std::vector<AllocatorPtr> OpenVINOExecutionProvider::CreatePreferredAllocators()
     AllocatorCreationInfo npu_allocator_info{
         [this](OrtDevice::DeviceId device_id) {
           return std::make_unique<OVRTAllocator>(
-              OVCore::Get(),
+              OVCore::Get()->core,
               OrtDevice::NPU,
               device_id,
               OpenVINO_RT_NPU);

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.h
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.h
@@ -45,7 +45,7 @@ static std::vector<std::string> split(const std::string& s, char delim) {
 // Logical device representation.
 class OpenVINOExecutionProvider : public IExecutionProvider {
  public:
-  explicit OpenVINOExecutionProvider(const ProviderInfo& info, SharedContext& shared_context);
+  explicit OpenVINOExecutionProvider(const ProviderInfo& info, std::shared_ptr<SharedContext> shared_context);
   ~OpenVINOExecutionProvider();
 
   std::vector<std::unique_ptr<ComputeCapability>>
@@ -69,7 +69,7 @@ class OpenVINOExecutionProvider : public IExecutionProvider {
 #endif
  private:
   SessionContext session_context_;
-  SharedContext& shared_context_;
+  std::shared_ptr<SharedContext> shared_context_;
   std::list<BackendManager> backend_managers_;  // EP session owns the backend objects
   EPCtxHandler ep_ctx_handle_;
 };

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -37,40 +37,64 @@ typedef ov::intel_gpu::ocl::ClContext* OVRemoteContextPtr;
 typedef ov::RemoteContext OVRemoteContext;
 #endif
 
-struct OVCore {
-  static void Initialize();
-  static void Teardown();
+template <typename T>
+class WeakSingleton {
+ public:
+  static std::shared_ptr<T> Get() {
+    static std::weak_ptr<T> instance;
+    static std::mutex mutex;
+
+    auto ptr = instance.lock();
+    if (!ptr) {
+      std::lock_guard<std::mutex> lock(mutex);
+      // ensure another thread didn't create an instance while this thread was waiting
+      ptr = instance.lock();
+      if (!ptr) {
+        ptr = std::make_shared<T>();
+        instance = ptr;
+      }
+    }
+    return ptr;
+  }
+
+ protected:
+  WeakSingleton() = default;
+  virtual ~WeakSingleton() = default;
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(WeakSingleton);
+};
+
+struct OVCore : WeakSingleton<OVCore> {
+  ov::Core core;
 
   // OV Interface For Reading Model
-  static std::shared_ptr<OVNetwork> ReadModel(const std::string& model_stream, const std::string& model_path);
+  std::shared_ptr<OVNetwork> ReadModel(const std::string& model_stream, const std::string& model_path);
 
   // OV Interface for Compiling OV Model Type
-  static OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
-                                   std::string& hw_target,
-                                   ov::AnyMap& device_config,
-                                   const std::string& name);
+  OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
+                            std::string& hw_target,
+                            ov::AnyMap& device_config,
+                            const std::string& name);
   // OV Interface for Fast Compile
-  static OVExeNetwork CompileModel(const std::string& onnx_model,
-                                   std::string& hw_target,
-                                   ov::AnyMap& device_config,
-                                   const std::string& name);
+  OVExeNetwork CompileModel(const std::string& onnx_model,
+                            std::string& hw_target,
+                            ov::AnyMap& device_config,
+                            const std::string& name);
   // OV Interface for Import model Stream
-  static OVExeNetwork ImportModel(std::istream& model_stream,
-                                  std::string hw_target,
-                                  const ov::AnyMap& device_config,
-                                  std::string name);
+  OVExeNetwork ImportModel(std::istream& model_stream,
+                           std::string hw_target,
+                           const ov::AnyMap& device_config,
+                           std::string name);
 #ifdef IO_BUFFER_ENABLED
-  static OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& model,
-                                   OVRemoteContextPtr context,
-                                   std::string name);
-  static OVExeNetwork ImportModel(std::shared_ptr<std::istringstream> model_stream,
-                                  OVRemoteContextPtr context,
-                                  std::string name);
+  OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& model,
+                            OVRemoteContextPtr context,
+                            std::string name);
+  OVExeNetwork ImportModel(std::shared_ptr<std::istringstream> model_stream,
+                           OVRemoteContextPtr context,
+                           std::string name);
 #endif
-  static std::vector<std::string> GetAvailableDevices();
-  static void SetCache(const std::string& cache_dir_path);
-  inline static ov::Core& Get();
-  static void SetStreams(const std::string& device_type, int num_streams);
+  std::vector<std::string> GetAvailableDevices();
+  void SetCache(const std::string& cache_dir_path);
+  void SetStreams(const std::string& device_type, int num_streams);
 };
 
 class OVExeNetwork {


### PR DESCRIPTION
Python bindings don't call the provider factory shutdown method. We relied on this to avoid destruction order issues with statically scoped ov::Core objects.

 Refactor ov core and shared context lifetimes such that we don't need to rely on shutdown
 calls to manage life times and we avoid a static lifetime of the core.



