### PR TITLE
[OVEP] Fix for deprecated OV element type

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -167,7 +167,7 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
   if (session_context_.precision.find("ACCURACY") != std::string::npos &&
       session_context_.device_type.find("GPU") != std::string::npos) {
     if (session_context_.OpenVINO_Version.at(0) >= 2024) {
-      device_config.emplace(ov::hint::inference_precision(ov::element::undefined));
+      device_config.emplace(ov::hint::inference_precision(ov::element::dynamic));
       device_config.emplace(ov::hint::execution_mode(ov::hint::ExecutionMode::ACCURACY));
     } else {
       if (!subgraph_context_.model_precision.empty())

--- a/onnxruntime/test/testdata/custom_op_openvino_wrapper_library/openvino_wrapper.cc
+++ b/onnxruntime/test/testdata/custom_op_openvino_wrapper_library/openvino_wrapper.cc
@@ -35,7 +35,7 @@ static ov::element::Type ConvertONNXToOVType(ONNXTensorElementDataType onnx_type
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
       return ov::element::bf16;
     default:
-      return ov::element::undefined;
+      return ov::element::dynamic;
   }
 }
 


### PR DESCRIPTION
This pr fixes the warning which comes when building OVEP with latest OV  


