### PR TITLE
Use absolute paths for libraries loaded with LOAD_WITH_ALTERED_SEARCH_PATH

### DIFF
--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -1307,7 +1307,7 @@ class TestInferenceSession(unittest.TestCase):
 
     def test_register_custom_ops_library(self):
         if sys.platform.startswith("win"):
-            shared_library = "custom_op_library.dll"
+            shared_library = os.path.abspath("custom_op_library.dll")
             if not os.path.exists(shared_library):
                 raise FileNotFoundError(f"Unable to find '{shared_library}'")
 
@@ -1724,7 +1724,7 @@ class TestInferenceSession(unittest.TestCase):
             return
 
         if sys.platform.startswith("win"):
-            shared_library = "test_execution_provider.dll"
+            shared_library = os.path.abspath("test_execution_provider.dll")
 
         elif sys.platform.startswith("darwin"):
             # exclude for macos


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
LoadLibrary behavior with relative paths when LOAD_WITH_ALTERED_SEARCH_PATH is used is unknown 

![image](https://github.com/user-attachments/assets/bdae0714-00d9-4e5a-8fbd-50bc772ad55c)



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Fixes the failures seen while running onnxruntime_test_python

