### PR TITLE
 Optimize Device Availability Check

### DIFF
--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -108,6 +108,7 @@ struct ProviderInfo {
 struct SessionContext : ProviderInfo {
   SessionContext(const ProviderInfo& info) : ProviderInfo{info} {}
   std::vector<bool> deviceAvailableList = {true, true, true, true, true, true, true, true};
+  std::vector<std::string> available_devices; // this vector will be used to validate available devices thoughout OVEP lifetime
   std::filesystem::path onnx_model_path_name;
   uint32_t onnx_opset_version{0};
   mutable bool is_wholly_supported_graph = false;  // Value is set to mutable to modify from capability

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -64,6 +64,9 @@ OpenVINOExecutionProvider::OpenVINOExecutionProvider(const ProviderInfo& info, s
   if (info.cache_dir.empty()) {
     bool device_found = false;
     std::vector<std::string> available_devices = OVCore::Get()->GetAvailableDevices();
+    for (int i = 0 ; i< available_devices.size() ; i++) {
+      session_context_.available_devices.push_back(available_devices[i]);
+    }
     // Checking for device_type configuration
     if (info.device_type != "") {
       if (info.device_type.find("HETERO") != std::string::npos ||

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -56,7 +56,6 @@ bool ParseBooleanOption(const ProviderOptions& provider_options, std::string opt
 }
 
 std::string ParseDeviceType(std::shared_ptr<OVCore> ov_core, const ProviderOptions& provider_options, std::string option_name) {
-  const std::vector<std::string> ov_available_devices = ov_core->GetAvailableDevices();
 
   std::set<std::string> ov_supported_device_types = {"CPU", "GPU",
                                                      "GPU.0", "GPU.1", "NPU"};
@@ -64,8 +63,6 @@ std::string ParseDeviceType(std::shared_ptr<OVCore> ov_core, const ProviderOptio
                                                    "GPU.0_FP32", "GPU.1_FP32", "GPU_FP16",
                                                    "GPU.0_FP16", "GPU.1_FP16"};
 
-  // Expand set of supported device with OV devices
-  ov_supported_device_types.insert(ov_available_devices.begin(), ov_available_devices.end());
 
   if (provider_options.contains(option_name)) {
     const auto& selected_device = provider_options.at("device_type");


### PR DESCRIPTION
### Description
This PR optimizes the device availability check in OVEP by removing redundant calls to get_available_devices(), which is an expensive function causing memory regression and high execution time.

Removed unnecessary get_available_devices() call in ParseDeviceType and openvino_execution_provider.cc.
Introduced a global vector to store the available devices at OVEP initialization.
The cached device list will persist throughout OVEP’s lifetime, preventing repeated calls to get_available_devices().



### Motivation and Context
Performance Improvement: Avoids multiple redundant calls to get_available_devices(), reducing initialization overhead.
Memory Optimization: Prevents unnecessary memory allocations from repeated device queries.

https://jira.devtools.intel.com/browse/HAFP-2960

FYI: get_available_devices() takes approximately 300 to 350 milliseconds for each call.

