### PR TITLE
Add support for parsing AUTO, HETERO and MULTI from json config

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -282,7 +282,9 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
         session_context_.device_type.find("HETERO") == 0 ||
         session_context_.device_type.find("MULTI") == 0) {
       //// Parse to get the device mode (e.g., "AUTO:CPU,GPU" -> "AUTO")
+      std::unordered_set<std::string> supported_mode = {"AUTO", "HETERO", "MULTI"};
       auto device_mode = find_device_type_mode(session_context_.device_type);
+      ORT_ENFORCE(supported_mode.find(device_mode)!=supported_mode.end(), " Invalid device mode is passed : " , session_context_.device_type);
       // Parse individual devices (e.g., "AUTO:CPU,GPU" -> ["CPU", "GPU"])
       auto individual_devices = parse_individual_devices(session_context_.device_type);
       if (!device_mode.empty()) individual_devices.emplace_back(device_mode);
@@ -297,8 +299,6 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
         }
       }
     } else {
-      std::unordered_set<std::string> valid_ov_devices = {"CPU", "GPU", "NPU", "AUTO", "HETERO", "MULTI"};
-
       if (target_config.count(session_context_.device_type)) {
         auto supported_properties = OVCore::Get()->core.get_property(session_context_.device_type,
                                                                      ov::supported_properties);

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -222,6 +222,15 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
         }
       }
     }
+    auto find_device_type_mode = [&](const std::string& device_type) -> std::string {
+      std::string device_mode="";
+      auto delimiter_pos = device_type.find(':');
+      if (delimiter_pos != std::string::npos) {
+        std::stringstream str_stream(device_type.substr(0, delimiter_pos));
+        std::getline(str_stream, device_mode, ',');
+      }
+      return device_mode;
+    };
 
     // Parse device types like "AUTO:CPU,GPU" and extract individual devices
     auto parse_individual_devices = [&](const std::string& device_type) -> std::vector<std::string> {
@@ -270,8 +279,12 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
     if (session_context_.device_type.find("AUTO") == 0 ||
         session_context_.device_type.find("HETERO") == 0 ||
         session_context_.device_type.find("MULTI") == 0) {
+      //// Parse to get the device mode (e.g., "AUTO:CPU,GPU" -> "AUTO")
+      auto device_mode = find_device_type_mode(session_context_.device_type);
       // Parse individual devices (e.g., "AUTO:CPU,GPU" -> ["CPU", "GPU"])
       auto individual_devices = parse_individual_devices(session_context_.device_type);
+      if(!device_mode.empty()) individual_devices.emplace_back(device_mode);
+
       // Set properties only for individual devices (e.g., "CPU", "GPU")
       for (const std::string& device : individual_devices) {
         if (target_config.count(device)) {
@@ -282,6 +295,8 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
         }
       }
     } else {
+      std::unordered_set<std::string> valid_ov_devices = {"CPU", "GPU", "NPU", "AUTO", "HETERO", "MULTI"};
+
       if (target_config.count(session_context_.device_type)) {
         auto supported_properties = OVCore::Get()->core.get_property(session_context_.device_type,
                                                                      ov::supported_properties);

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -2,6 +2,8 @@
 // Licensed under the MIT License
 
 #include <map>
+#include <unordered_set>
+
 #include <string>
 #include <memory>
 #include <sstream>
@@ -223,7 +225,7 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
       }
     }
     auto find_device_type_mode = [&](const std::string& device_type) -> std::string {
-      std::string device_mode="";
+      std::string device_mode = "";
       auto delimiter_pos = device_type.find(':');
       if (delimiter_pos != std::string::npos) {
         std::stringstream str_stream(device_type.substr(0, delimiter_pos));
@@ -283,7 +285,7 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
       auto device_mode = find_device_type_mode(session_context_.device_type);
       // Parse individual devices (e.g., "AUTO:CPU,GPU" -> ["CPU", "GPU"])
       auto individual_devices = parse_individual_devices(session_context_.device_type);
-      if(!device_mode.empty()) individual_devices.emplace_back(device_mode);
+      if (!device_mode.empty()) individual_devices.emplace_back(device_mode);
 
       // Set properties only for individual devices (e.g., "CPU", "GPU")
       for (const std::string& device : individual_devices) {

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -216,9 +216,9 @@ struct OpenVINO_Provider : Provider {
 
           for (auto& [key, value] : json_config.items()) {
             ov::AnyMap inner_map;
-
+            std::unordered_set<std::string> valid_ov_devices = {"CPU", "GPU", "NPU", "AUTO", "HETERO", "MULTI"};
             // Ensure the key is one of "CPU", "GPU", or "NPU"
-            if (key != "CPU" && key != "GPU" && key != "NPU") {
+            if (valid_ov_devices.find(key) == valid_ov_devices.end()) {
               LOGS_DEFAULT(WARNING) << "Unsupported device key: " << key << ". Skipping entry.\n";
               continue;
             }

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -2,6 +2,8 @@
 // Licensed under the MIT License
 
 #include <map>
+#include <set>
+
 #include <utility>
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/openvino/openvino_provider_factory.h"
@@ -216,7 +218,7 @@ struct OpenVINO_Provider : Provider {
 
           for (auto& [key, value] : json_config.items()) {
             ov::AnyMap inner_map;
-            std::unordered_set<std::string> valid_ov_devices = {"CPU", "GPU", "NPU", "AUTO", "HETERO", "MULTI"};
+            std::set<std::string> valid_ov_devices = {"CPU", "GPU", "NPU", "AUTO", "HETERO", "MULTI"};
             // Ensure the key is one of "CPU", "GPU", or "NPU"
             if (valid_ov_devices.find(key) == valid_ov_devices.end()) {
               LOGS_DEFAULT(WARNING) << "Unsupported device key: " << key << ". Skipping entry.\n";


### PR DESCRIPTION
### Description
Add parsing for different mode execution via config file in OVEP


### Motivation and Context
Support for the AUTO properties like ENABLE_RUNTIME_FALLBACK needs to be added in OVEP. 

Sample .json file for this feature is :

auto_config.json

{
    "AUTO":
    {"ENABLE_STARTUP_FALLBACK":"NO",
    "ENABLE_RUNTIME_FALLBACK" : "NO",
    "EXECUTION_MODE_HINT" : "ACCURACY"}
}

The properties for a specified hardware is obtained from OV. Adding the syntax to print supported OV properties for a device using C++  API 

```
auto device = "AUTO";
auto device_properties = ov::core.get_property(device, ov::supported_properties);
  //print device properties
  std::cout << " Properties for " << device << " : " << std::endl;
  for(auto& it : device_properties) {
    std::cout << it << std::endl;
  }
```

For checking whether the property is set correctly during OV model compilation, we can get and print the properties from OV compiled model using the below snippet in C++ 
```
    // output of the actual settings that the device selected
    auto compiledModel = ov::core.compile_model(onnx_model, ov::Tensor(), hw_target, device_config);
    auto supported_properties = compiledModel.get_property(ov::supported_properties);
    std::cout << "Model:" << std::endl;
    for (const auto& cfg : supported_properties) {
        if (cfg == ov::supported_properties)
            continue;
        auto prop = compiledModel.get_property(cfg);
        if (cfg == ov::device::properties) {
            auto devices_properties = prop.as<ov::AnyMap>();
            for (auto& item : devices_properties) {
                std::cout << "  " << item.first << ": " << std::endl;
                for (auto& item2 : item.second.as<ov::AnyMap>()) {
                    std::cout << "    " << item2.first << ": " << item2.second.as<std::string>() << std::endl;
                }
            }
        } else {
            std::cout << "  " << cfg << ": " << prop.as<std::string>() << std::endl;
        }
    }

```
 
[HAFP-3004](https://jira.devtools.intel.com/browse/HAFP-3004)

