### PR TITLE
Map device_id to OV LUID

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -691,11 +691,7 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
               " HETERO/MULTI/AUTO options available. \n");
         }
       } else if (key == "device_id") {
-        if (value == "CPU" || value == "GPU" || value == "NPU") {
-          ov_options[key] = value;
-        } else {
-          ORT_THROW("[ERROR] [OpenVINO] Unsupported device_id is selected. Select from available options.");
-        }
+        ov_options[key] = value;
       } else if (key == "precision") {
         auto device_type = ov_options["device_type"];
         if (device_type.find("GPU") != std::string::npos) {


### PR DESCRIPTION
### Description
Add support for passing LUID via device_id provider option and map it with appropriate GPU device using OV get_property


[HAFP-3007](https://jira.devtools.intel.com/browse/HAFP-3007)
