### PR TITLE
[OVEP] Added Cast and Resize to operators that handle zero-valued dimensions, preventing unnecessary fallback

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -792,7 +792,8 @@ bool DataOps::node_is_supported(const NodeIndex node_idx, bool& has_external_wei
             if (((device_id_.find("CPU") != std::string::npos) || (device_id_.find("GPU") != std::string::npos)) &&
                 ((optype == "Expand") || (optype == "Equal") ||
                  (optype == "Slice") || (optype == "Concat") ||
-                 (optype == "Shape"))) {
+                 (optype == "Shape") || (optype == "Cast") ||
+                 (optype == "Resize"))) {
               return;
             }
             has_unsupported_dimension = true;


### PR DESCRIPTION
This Pr is a fix for Jira ticket https://jira.devtools.intel.com/browse/CVS-150504

