### PR TITLE
Add SimpLayerNorm, GQA to supported_ops

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -255,6 +255,8 @@ std::vector<SupportedOp> supported_op_mode = {
     {"Unsqueeze", V_2020_4, {"CPU", "GPU"}},
     {"Where", V_2022_1, {"CPU", "GPU"}},
     {"Xor", V_2022_1, {"CPU", "GPU"}},
+    {"GroupQueryAttention", V_2025_1, {"CPU", "GPU"}},
+    {"SimplifiedLayerNormalization", V_2025_1, {"CPU", "GPU"}},
 };
 
 void DataOps::populate_types_supported() {
@@ -388,6 +390,7 @@ void DataOps::populate_op_mode_supported() {
   no_dimension_supported_.push_back({"Sub", V_2020_4, {"All"}});
   no_dimension_supported_.push_back({"Unsqueeze", V_2020_4, {"All"}});
   no_dimension_supported_.push_back({"Where", V_2021_2, {"All"}});
+  no_dimension_supported_.push_back({"GroupQueryAttention", V_2025_1, {"All"}});
 
   subgraph_supported_.push_back({"Cast", V_2020_4, {"All"}});
   subgraph_supported_.push_back({"Concat", V_2020_4, {"All"}});


### PR DESCRIPTION
### Description
Added GroupQueryAttention and SimplifiedLayerNormalization to supported ops.

### Motivation and Context
With these two PR https://github.com/openvinotoolkit/openvino/pull/28963 https://github.com/openvinotoolkit/openvino/pull/28163 merged into OpenVINO, ONNX models generated by onnxruntime-genai containing these two ops will work.

Example models: [Phi3](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-onnx) and Llama3 generated by the following command:
```
python -m onnxruntime_genai.models.builder -m meta-llama/Llama-3.1-8B-Instruct -o E:\download\onnx\llama3.1-8B-instruct-onnx -p int4 -e cpu -i E:\download\huggingface\llama3.1-8B-instruct
```

