### PR TITLE
Device type refactoring 

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -284,7 +284,7 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
       //// Parse to get the device mode (e.g., "AUTO:CPU,GPU" -> "AUTO")
       std::unordered_set<std::string> supported_mode = {"AUTO", "HETERO", "MULTI"};
       auto device_mode = find_device_type_mode(session_context_.device_type);
-      ORT_ENFORCE(supported_mode.find(device_mode)!=supported_mode.end(), " Invalid device mode is passed : " , session_context_.device_type);
+      ORT_ENFORCE(supported_mode.find(device_mode) != supported_mode.end(), " Invalid device mode is passed : ", session_context_.device_type);
       // Parse individual devices (e.g., "AUTO:CPU,GPU" -> ["CPU", "GPU"])
       auto individual_devices = parse_individual_devices(session_context_.device_type);
       if (!device_mode.empty()) individual_devices.emplace_back(device_mode);

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 #include <string>
 #include <filesystem>
 #include <memory>

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -102,6 +102,9 @@ struct ProviderInfo {
   bool so_share_ep_contexts{false};        // ORT session option
   fs::path so_context_file_path{};         // ORT session option
   const ConfigOptions* config_options{NULL};
+  const std::unordered_set<std::string> valid_provider_keys = {"device_type", "device_id", "device_luid", "cache_dir",
+                                                               "load_config", "context", "num_of_threads", "model_priority", "num_streams", "enable_opencl_throttling", "enable_qdq_optimizer",
+                                                               "disable_dynamic_shapes"};
 };
 
 // Holds context applicable to the entire EP instance.

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -58,8 +58,8 @@ bool ParseBooleanOption(const ProviderOptions& provider_options, std::string opt
 }
 
 std::string ParseDeviceType(std::shared_ptr<OVCore> ov_core, const ProviderOptions& provider_options) {
-  std::unordered_set<std::string> supported_device_types = {"CPU", "GPU", "NPU"};
-  std::unordered_set<std::string> supported_device_modes = {"AUTO", "HETERO", "MULTI"};
+  std::set<std::string> supported_device_types = {"CPU", "GPU", "NPU"};
+  std::set<std::string> supported_device_modes = {"AUTO", "HETERO", "MULTI"};
   std::vector<std::string> devices_to_check;
   std::string selected_device;
   std::vector<std::string> luid_list;
@@ -76,7 +76,7 @@ std::string ParseDeviceType(std::shared_ptr<OVCore> ov_core, const ProviderOptio
         devices_to_check = split(devices, ',');
         ORT_ENFORCE(devices_to_check.size() > 0, "Modes should have devices listed based on priority");
       } else {
-        ORT_THROW("[ERROR] [OpenVINO] Invlid device_type is selected");
+        ORT_THROW("[ERROR] [OpenVINO] Invalid device_type is selected");
       }
     } else {
       devices_to_check.push_back(selected_device);
@@ -131,7 +131,7 @@ std::string ParseDeviceType(std::shared_ptr<OVCore> ov_core, const ProviderOptio
         // Here we need to find the full device name (with .idx, but without _precision)
         if (std::find(std::begin(available_devices), std::end(available_devices), device) != std::end(available_devices))
           device_found = true;
-        if (device_prefix == "GPU" and luid_list.size() > 0) {
+        if (device_prefix == "GPU" && luid_list.size() > 0) {
           std::map<std::string, std::string> ov_luid_map;
           for (auto gpu_dev : available_devices) {
             ov::device::LUID ov_luid = OVCore::Get()->core.get_property(gpu_dev, ov::device::luid);
@@ -148,8 +148,9 @@ std::string ParseDeviceType(std::shared_ptr<OVCore> ov_core, const ProviderOptio
                   if (dev_str.find("GPU") != std::string::npos)
                     selected_device = selected_device + "," + dev_str;
                 }
-              } else
+              } else {
                 selected_device = ov_dev;
+              }
             } else {
               ORT_THROW("Invalid device_luid is set");
             }
@@ -161,7 +162,7 @@ std::string ParseDeviceType(std::shared_ptr<OVCore> ov_core, const ProviderOptio
     }
     all_devices_found = all_devices_found && device_found;
   }
-  // If invalid device is choosen error is thrown
+  // If invalid device is chosen error is thrown
   if (!all_devices_found)
     ORT_THROW(
         "[ERROR] [OpenVINO] You have selected wrong configuration value for the key 'device_type'. "

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -178,25 +178,31 @@ std::vector<std::string> OVCore::GetAvailableDevices(const std::string& device_t
   } catch (const ov::Exception&) {
     // plugin is not created by e.g. invalid env
     // Empty device list will be returned
-  } catch (const std::runtime_error&) {
+  } catch (const std::runtime_error& ex) {
     // plugin is not created by e.g. invalid env
     // Empty device list will be returned
+    ORT_THROW("[ERROR] [OpenVINO] An exception occured while trying to create the ",
+              device_type,
+              " device: ",
+              ex.what());
   } catch (const std::exception& ex) {
-    ORT_THROW("[ERROR] [OpenVINO] An exception is thrown while trying to create the ",
+    ORT_THROW("[ERROR] [OpenVINO] An exception occured while trying to create the ",
               device_type,
               " device: ",
               ex.what());
   } catch (...) {
-    ORT_THROW("[ERROR] [OpenVINO] Unknown exception is thrown while trying to create the ",
+    ORT_THROW("[ERROR] [OpenVINO] Unknown exception occured while trying to create the ",
               device_type,
               " device");
   }
 
-  if (devicesIDs.size() > 1) {
+  if (devicesIDs.size() > 1 ||
+      (devicesIDs.size() == 1 && devicesIDs[0] == "0")) {
     for (const auto& deviceID : devicesIDs) {
       available_devices.push_back(device_type + '.' + deviceID);
     }
-  } else if (!devicesIDs.empty()) {
+  }
+  if (!devicesIDs.empty()) {
     available_devices.push_back(device_type);
   }
 

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -181,17 +181,17 @@ std::vector<std::string> OVCore::GetAvailableDevices(const std::string& device_t
   } catch (const std::runtime_error& ex) {
     // plugin is not created by e.g. invalid env
     // Empty device list will be returned
-    ORT_THROW("[ERROR] [OpenVINO] An exception occured while trying to create the ",
+    ORT_THROW("[ERROR] [OpenVINO] An exception occurred while trying to create the ",
               device_type,
               " device: ",
               ex.what());
   } catch (const std::exception& ex) {
-    ORT_THROW("[ERROR] [OpenVINO] An exception occured while trying to create the ",
+    ORT_THROW("[ERROR] [OpenVINO] An exception occurred while trying to create the ",
               device_type,
               " device: ",
               ex.what());
   } catch (...) {
-    ORT_THROW("[ERROR] [OpenVINO] Unknown exception occured while trying to create the ",
+    ORT_THROW("[ERROR] [OpenVINO] Unknown exception occurred while trying to create the ",
               device_type,
               " device");
   }

--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_stripping.cc
@@ -386,7 +386,7 @@ static bool CheckQRuleSet(const NodeUnit& node_unit,
   } else if (op_type == "Add") {
     // Add keeps all Qs
     return true;
-  }  else {
+  } else {
     // Keep Q of an unsupported Op only if the target that succeeds it is a supported Op in this list
     return IsNextTargetNodeOfQValid(q_node, &target_node, src_graph, {"Conv", "Add", "MatMul"}, false);
   }

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -792,6 +792,8 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
         }
       } else if (key == "device_memory_name") {
         device_memory_name_ = std::move(value);
+      } else if (key == "device_luid") {
+        ov_options[key] = value;
       } else {
         ORT_THROW(
             "[ERROR] [OpenVINO] wrong key type entered. Choose from the following runtime key options that are available for OpenVINO."

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -680,11 +680,11 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
           ov_options[key] = value;
         } else if (deprecated_device_types.find(value) != deprecated_device_types.end()) {
           ov_options[key] = value;
-        } else if (value.find("HETERO:") == 0) {
+        } else if (value.find("HETERO") == 0) {
           ov_options[key] = value;
-        } else if (value.find("MULTI:") == 0) {
+        } else if (value.find("MULTI") == 0) {
           ov_options[key] = value;
-        } else if (value.find("AUTO:") == 0) {
+        } else if (value.find("AUTO") == 0) {
           ov_options[key] = value;
         } else {
           ORT_THROW(


### PR DESCRIPTION
Hi. The PR handles the following JIRA's 
https://jira.devtools.intel.com/browse/CVS-165227
https://jira.devtools.intel.com/browse/CVS-164697
https://jira.devtools.intel.com/browse/CVS-165140
 
These scenarios needs to be validated
 
 
For LUID testing, 
get the luid of device using python openvino snippet , 
import openvino as ov 
core = ov.Core()
luid = core.get_property("GPU.<id>", "DEVICE_LUID")
print luid
This luid can be passed to ovep provider option like , 
ProviderOpitons ov_options;
ov_options[device_type]=AUTO:GPU,CPU;
ov_options[device_luid] = beff000000000000
 
 
 
Checks to be done : 
device_type must be set and it should have GPU in it. 
For eg :
GPU 
AUTO:GPU 
AUTO:GPU.0, GPU.1, CPU  
 
device_luid can consist of multiple LUIDs. But they must be comma seperated. Each of the LUID must correspond to a GPU HW. Even if single LUID is incorrect the error must be thrown 
 
Expected output in case of multiple GPU's specified and single LUID is passed is 
For device_type=AUTO:GPU.2, GPU.1, GPU.0, CPU and device_luid = beff000000000000 (that corresponds to GPU.1) , then device_type should be 
AUTO:GPU.1, CPU
 