### PR TITLE
Pass ov::Model as mutable into OVCore::CompileModel

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_utils.cc
+++ b/onnxruntime/core/providers/openvino/backend_utils.cc
@@ -136,7 +136,7 @@ bool IsCILogEnabled() {
   return false;
 }
 
-std::shared_ptr<const OVNetwork>
+std::shared_ptr<OVNetwork>
 CreateOVModel(const std::string model,
               const SessionContext& session_context,
               std::map<std::string, std::shared_ptr<ov::Node>>& const_outputs_map) {

--- a/onnxruntime/core/providers/openvino/backend_utils.h
+++ b/onnxruntime/core/providers/openvino/backend_utils.h
@@ -61,7 +61,7 @@ void FillInputBlob(OVTensorPtr inputBlob, size_t batch_slice_idx,
 void FillOutputBlob(OVTensorPtr outputBlob, Ort::UnownedValue& output_tensor,
                     size_t batch_slice_idx);
 
-std::shared_ptr<const OVNetwork>
+std::shared_ptr<OVNetwork>
 CreateOVModel(const std::string model,
               const SessionContext& session_context,
               std::map<std::string, std::shared_ptr<ov::Node>>& const_outputs_map);

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -108,7 +108,7 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
                                                  subgraph_context_.subgraph_name);
     } else {  // For all other types use ov::ov_core read_model() to generate OV IR
               // followed by ov::ov_core compile_model()
-      std::shared_ptr<const OVNetwork> ov_model;
+      std::shared_ptr<OVNetwork> ov_model;
       {
         const std::string model = model_proto->SerializeAsString();
         if (!subgraph_context.has_dynamic_input_shape) {

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -70,7 +70,7 @@ struct OVCore : WeakSingleton<OVCore> {
   std::shared_ptr<OVNetwork> ReadModel(const std::string& model_stream, const std::string& model_path);
 
   // OV Interface for Compiling OV Model Type
-  OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
+  OVExeNetwork CompileModel(std::shared_ptr<OVNetwork>& ie_cnn_network,
                             std::string& hw_target,
                             ov::AnyMap& device_config,
                             const std::string& name);


### PR DESCRIPTION
For stateless -> stateful pass, we need to patch the model. Since ov::Compiled model was passed as non-mutable (const), this required us to clone the model, which adds some unnecessary time and memory consumption. 

So, here are some changes that pass ov::Model as mutable so that we can patch the model directly.


