### PR TITLE
[OVEP] Fix for building OVEP without vcpkg flag

### DIFF
--- a/tools/ci_build/github/linux/run_build.sh
+++ b/tools/ci_build/github/linux/run_build.sh
@@ -37,7 +37,7 @@ if [ $BUILD_OS = "yocto" ]; then
 
     make -j$(nproc)
 else
-    COMMON_BUILD_ARGS="--skip_submodule_sync --enable_onnx_tests --parallel --use_vcpkg --use_binskim_compliant_compile_flags --cmake_path /usr/bin/cmake --ctest_path /usr/bin/ctest"
+    COMMON_BUILD_ARGS="--skip_submodule_sync --enable_onnx_tests --parallel --use_binskim_compliant_compile_flags --cmake_path /usr/bin/cmake --ctest_path /usr/bin/ctest"
 
     if [ $BUILD_DEVICE = "gpu" ]; then
         _CUDNN_VERSION=$(echo $CUDNN_VERSION | cut -d. -f1-2)


### PR DESCRIPTION
Removed the vcpkg flag as there is an installation issue with vcpkg, vcpkg is completely handled by ort , other EP's have disabled vcpkg installation as well , thus removing it,  Pasting some examples of other EP's

https://github.com/intel/onnxruntime/pull/636/commits/259214768adc2545f570643c43e44d2de8e2bdd6
https://github.com/intel/onnxruntime/pull/636/commits/bd00c39f36bcab79ce44f27042bb5112064aa367
https://github.com/intel/onnxruntime/pull/636/commits/2a800d1e4f6a9ac4a8727e1b6b943de0ea492fb5


