### PR TITLE
Release model proto after we have the serialized string to reduce peak memory consumption

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -98,9 +98,11 @@ BasicBackend::BasicBackend(std::unique_ptr<ONNX_NAMESPACE::ModelProto>& model_pr
                auto_unified_compile) {
       // Unified OV compile_model is efficient when ov model caching is enabled
       // Unified OV compile_model API is supported with AUTO from version 2024.3 and above
-      // Inputs with static dimenstions
+      // Inputs with static dimensions
       // Not enabled for models with external weights and when ep context is set.
       const std::string model = model_proto->SerializeAsString();
+      // we have the serialized string, so we can release model proto to lower the peak memory consumption
+      model_proto.reset();
       exe_network_ = OVCore::Get()->CompileModel(model,
                                                  hw_target,
                                                  device_config,


### PR DESCRIPTION
Once we have the serialized string, we can remove the proto object from memory

### Description
Call the reset, as in the "else" statement



### Motivation and Context
Reduces the peak memory consumption by roughly 1x model size
https://jira.devtools.intel.com/browse/VGD-26545

