### PR TITLE
feat: ORT GenAI Stateful Compilation changes

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -105,7 +105,8 @@ BackendManager::BackendManager(SessionContext& session_context,
     subgraph_context_.has_dynamic_input_shape = true;
     LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Model has symbolic input dims";
     if ((session_context_.device_type.find("CPU") != std::string::npos ||
-         session_context_.device_type.find("GPU") != std::string::npos) &&
+         session_context_.device_type.find("GPU") != std::string::npos ||
+         (session_context_.device_type.find("NPU") != std::string::npos && session_context_.enable_causallm)) &&
         !session_context_.disable_dynamic_shapes) {
       LOGS_DEFAULT(INFO) << "[OpenVINO-EP] Starting backend initialization. "
                          << "Creating backend Dynamic Shapes";
@@ -492,7 +493,9 @@ void BackendManager::Compute(OrtKernelContext* context) {
   if (subgraph_context_.has_dynamic_input_shape &&
       !session_context_.disable_dynamic_shapes &&
       (session_context_.device_type.find("CPU") != std::string::npos ||
-       session_context_.device_type.find("GPU") != std::string::npos)) {
+       session_context_.device_type.find("GPU") != std::string::npos ||
+       (session_context_.device_type.find("NPU") != std::string::npos &&
+        session_context_.enable_causallm))) {
     concrete_backend_->Infer(context);
   } else if (subgraph_context_.has_dynamic_input_shape) {
     std::vector<std::vector<int64_t>> tensor_shapes = GetInputTensorShapes(ctx);
@@ -563,6 +566,12 @@ void BackendManager::Compute(OrtKernelContext* context) {
 void BackendManager::ShutdownBackendManager() {
   backend_map_.clear();
   concrete_backend_.reset();
+}
+
+void BackendManager::RewindKVCache(size_t index) {
+  if (concrete_backend_) {
+    concrete_backend_->RewindKVCache(index);
+  }
 }
 
 }  // namespace openvino_ep

--- a/onnxruntime/core/providers/openvino/backend_manager.h
+++ b/onnxruntime/core/providers/openvino/backend_manager.h
@@ -30,6 +30,7 @@ class BackendManager {
   SessionContext& GetSessionContext();
   Status ExportCompiledBlobAsEPCtxNode(const onnxruntime::GraphViewer& subgraph);
   ov::CompiledModel& GetOVCompiledModel();
+  void RewindKVCache(size_t index);
 
  private:
   std::unique_ptr<ONNX_NAMESPACE::ModelProto> GetModelProtoFromFusedNode(

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -41,6 +41,7 @@ class BasicBackend : public IBackend {
   ov::CompiledModel& GetOVCompiledModel() override {
     return exe_network_.Get();
   }
+  void RewindKVCache(size_t index) override;
 
  private:
   void PopulateCompiledDirectory(std::string, std::string&, std::string&, bool&);
@@ -78,7 +79,7 @@ class InferRequestsQueue {
   InferRequestsQueue(OVExeNetwork& net, size_t nireq, std::function<void(OVInferRequestPtr)> initializer) {
     OVInferRequestPtr infer_request;
     for (size_t id = 0; id < nireq; id++) {
-      infer_request = std::make_shared<OVInferRequest>(net.CreateInferRequest());
+      infer_request = net.CreateInferRequest();
       initializer(infer_request);
       infer_requests_.push_back(infer_request);
     }

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -97,6 +97,7 @@ struct ProviderInfo {
   bool disable_dynamic_shapes{false};      // [disable_dynamic_shapes]:  Rewrite dynamic shaped models to
                                            // static shape at runtime and execute.
   bool enable_qdq_optimizer{false};        // Enables QDQ pruning for efficient inference latency with NPU
+  bool enable_causallm{false};             // Enables Causal LM Compilation for ORT GenAI OVEP Pass
   bool so_context_enable{false};           // ORT session option
   bool so_disable_cpu_ep_fallback{false};  // ORT session option
   bool so_context_embed_mode{false};       // ORT session option

--- a/onnxruntime/core/providers/openvino/ibackend.h
+++ b/onnxruntime/core/providers/openvino/ibackend.h
@@ -17,6 +17,7 @@ class IBackend {
   virtual void Infer(OrtKernelContext* context) = 0;
   virtual ov::CompiledModel& GetOVCompiledModel() = 0;
   virtual ~IBackend() = default;
+  virtual void RewindKVCache(size_t index) {};
 };
 using ptr_stream_t = std::unique_ptr<std::istream>;
 class BackendFactory {

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -244,6 +244,25 @@ common::Status OpenVINOExecutionProvider::SetEpDynamicOptions(gsl::span<const ch
           ov_compiled_model.set_property(ov::workload_type(workload_type));
         }
       }
+    } else if (key == "kvcache_rewind") {
+      // Convert kvcache_rewind value to int64_t
+      int64_t index;
+      try {
+        index = std::stoll(value);
+      } catch (const std::exception& e) {
+        LOGS_DEFAULT(WARNING) << "Conversion for kvcache_rewind string value to int64_t index failed."
+                              << "Exception:" + std::string(e.what());
+        return Status::OK();
+      }
+
+      // Trigger KVCache Rewind for target Backend
+      for (auto& backend : backend_managers_) {
+        if (index >= 0) {
+          backend.RewindKVCache(static_cast<size_t>(index));
+        } else {
+          LOGS_DEFAULT(WARNING) << "kvcache_rewind index is < 0:\t" << index;
+        }
+      }
     } else {
       // Handle unknown options
       LOGS_DEFAULT(WARNING) << "Unknown key/value pair - ignoring " << key << "/" << value;

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -343,13 +343,20 @@ static void ParseProviderInfo(const ProviderOptions& provider_options,
 
     pi.enable_qdq_optimizer = ParseBooleanOption(provider_options, "enable_qdq_optimizer");
 
+    pi.enable_causallm = ParseBooleanOption(provider_options, "enable_causallm");
+
     pi.disable_dynamic_shapes = ParseBooleanOption(provider_options, "disable_dynamic_shapes");
   } catch (std::string msg) {
     ORT_THROW(msg);
   }
   // Always true for NPU plugin or when passed .
   if (pi.device_type.find("NPU") != std::string::npos) {
-    pi.disable_dynamic_shapes = true;
+    // For Stateful Compilation i.e. enable_causallm as True, we use the dynamic shapes path.
+    if (pi.enable_causallm) {
+      pi.disable_dynamic_shapes = false;
+    } else {
+      pi.disable_dynamic_shapes = true;
+    }
   }
 }
 

--- a/onnxruntime/core/providers/openvino/ov_interface.cc
+++ b/onnxruntime/core/providers/openvino/ov_interface.cc
@@ -7,6 +7,8 @@
 #include "core/session/onnxruntime_cxx_api.h"
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/openvino/backend_utils.h"
+#include "core/providers/openvino/backends/basic_backend.h"
+#include "core/providers/openvino/ov_stateful_patch_utils.h"
 
 using Exception = ov::Exception;
 
@@ -82,17 +84,85 @@ std::shared_ptr<OVNetwork> OVCore::ReadModel(std::string&& model, const std::str
   }
 }
 
+OVExeNetwork OVCore::StatefulCompileModel(std::shared_ptr<OVNetwork>& model,
+                                          std::string& hw_target,
+                                          const ov::AnyMap& device_config) {
+  ov::CompiledModel compiled_model;
+  ov::AnyMap config = device_config;
+
+  if (onnxruntime::openvino_ep::backend_utils::IsDebugEnabled()) {
+    std::cout << "Stateless OV Model Statistic:" << std::endl;
+    LogBasicModelInfo(model);
+  }
+
+  LOGS_DEFAULT(INFO) << log_tag << "Converting from Stateless OV Model to Stateful OV Model" << std::endl;
+  bool model_status = IsStateful(model);
+  LOGS_DEFAULT(INFO) << log_tag << "Model IsStateful() Status:\t" << (model_status ? "True" : "False");
+  if (!model_status) {
+    PatchStatefulDecoder(model);
+  }
+
+  if (onnxruntime::openvino_ep::backend_utils::IsDebugEnabled()) {
+    std::cout << "Stateful OV Model Statistic:" << std::endl;
+    LogBasicModelInfo(model);
+  }
+
+  auto kv_pos = GetKVAxesPos(model);
+
+  if (hw_target.find("NPU") != std::string::npos) {
+    KVDesc kv_desc;
+    auto parse_genai_config = [&](const std::string& key, unsigned int default_value) {
+      return (config.count(key) && !config.at(key).empty() && config.at(key).as<std::string>() != "0") ? config.at(key).as<unsigned int>() : default_value;
+    };
+
+    kv_desc.max_prompt_len = parse_genai_config("MAX_PROMPT_LEN", CausalLMConfig().max_prompt_len);
+    kv_desc.min_response_len = parse_genai_config("MIN_RESPONSE_LEN", CausalLMConfig().min_response_len);
+
+    // For compilation, MAX_PROMPT_LEN & MIN_RESPONSE_LEN should not be 0
+    if (kv_desc.max_prompt_len == 0 || kv_desc.min_response_len == 0) {
+      ORT_THROW(log_tag + "MAX_PROMPT_LEN and MIN_RESPONSE_LEN cannot be 0 or empty");
+    }
+
+    if (onnxruntime::openvino_ep::backend_utils::IsDebugEnabled()) {
+      std::cout << "kv_pos.batch = " << kv_pos.batch << std::endl;
+      std::cout << "kv_pos.seq_len = " << kv_pos.seq_len << std::endl;
+      std::cout << "kv_desc.max_prompt_len:\t" << kv_desc.max_prompt_len << std::endl;
+      std::cout << "kv_desc.min_response_len:\t" << kv_desc.min_response_len << std::endl;
+    }
+
+    UpdateNPUConfig(config, kv_pos, kv_desc);
+  } else {
+    // This patches the OV IR model so that it only produces the logits required for sampling.
+    // Actually either way that happens within NPUW::LLMCompiledModel creation for NPU device,
+    // while this is here mostly to align this behavior for other devices viz. (CPU, GPU).
+    ApplySliceBeforeMatmulTransformation(model);
+  }
+
+  LOGS_DEFAULT(INFO) << log_tag << "Compiling OV Model using Stateful Transformation flow";
+  compiled_model = OVCore::Get()->core.compile_model(model, hw_target, config);
+  OVExeNetwork exe(compiled_model, hw_target, true);
+  return exe;
+}
+
 OVExeNetwork OVCore::CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
                                   std::string& hw_target,
                                   ov::AnyMap& device_config,
+                                  bool enable_causallm,
                                   const std::string& name) {
-  ov::CompiledModel obj;
+  OVExeNetwork exe;
   try {
-    obj = core.compile_model(ie_cnn_network, hw_target, device_config);
+    if (enable_causallm) {
+      auto mutable_model = ie_cnn_network->clone();
+      exe = OVCore::Get()->StatefulCompileModel(mutable_model, hw_target, device_config);
+    } else {
+      auto obj = core.compile_model(ie_cnn_network, hw_target, device_config);
+      exe = OVExeNetwork(obj, hw_target);
+    }
+
 #ifndef NDEBUG
-    printDebugInfo(obj);
+    printDebugInfo(exe.Get());
 #endif
-    OVExeNetwork exe(obj);
+
     return exe;
   } catch (const Exception& e) {
     ORT_THROW(log_tag + " Exception while Loading Network for graph: " + name + e.what());
@@ -111,7 +181,7 @@ OVExeNetwork OVCore::CompileModel(const std::string& onnx_model,
 #ifndef NDEBUG
     printDebugInfo(obj);
 #endif
-    OVExeNetwork exe(obj);
+    OVExeNetwork exe(obj, hw_target);
     return exe;
   } catch (const Exception& e) {
     ORT_THROW(log_tag + " Exception while Loading Network for graph: " + name + e.what());
@@ -128,9 +198,9 @@ OVExeNetwork OVCore::ImportModel(std::istream& model_stream,
     ov::CompiledModel obj;
     obj = core.import_model(model_stream, hw_target, device_config);
 #ifndef NDEBUG
-    printDebugInfo(obj);
+    printDebugInfo(exe.Get());
 #endif
-    OVExeNetwork exe(obj);
+    OVExeNetwork exe(obj, hw_target);
     return exe;
   } catch (const Exception& e) {
     ORT_THROW(log_tag + " Exception while Loading Network for graph: " + name + e.what());
@@ -224,11 +294,16 @@ void OVCore::SetStreams(const std::string& device_type, int num_streams) {
   core.set_property(device_type, {ov::num_streams(num_streams)});
 }
 
-OVInferRequest OVExeNetwork::CreateInferRequest() {
+std::shared_ptr<OVInferRequest> OVExeNetwork::CreateInferRequest() {
   try {
-    auto infReq = obj.create_infer_request();
-    OVInferRequest inf_obj(std::move(infReq));
-    return inf_obj;
+    auto infReq = compiled_model_obj.create_infer_request();
+    std::shared_ptr<OVInferRequest> ovInfReq;
+    if (is_stateful_causallm) {
+      ovInfReq = std::make_shared<StatefulOVInferRequest>(std::move(infReq), target_device);
+    } else {
+      ovInfReq = std::make_shared<OVInferRequest>(std::move(infReq));
+    }
+    return ovInfReq;
   } catch (const Exception& e) {
     ORT_THROW(log_tag + "Exception while creating InferRequest object: " + e.what());
   } catch (...) {
@@ -307,5 +382,134 @@ void OVInferRequest::QueryStatus() {
   std::cout << "ovInfReq.query_state()"
             << " ";
 }
+
+StatefulOVInferRequest::StatefulOVInferRequest(ov::InferRequest infer_request, std::string device)
+    : OVInferRequest(std::move(infer_request)), target_device(device) {
+  if ((device.find("NPU") != std::string::npos) || (device.find("GPU") != std::string::npos)) {
+    prefill_use_full_chat_history = true;
+  }
+}
+
+void StatefulOVInferRequest::PreProcessInferRequest() {
+  // Workaround: Setting the value here as it cannot be set at the ORT GenAI layer currently.
+  // TODO: Address this issue and implement the fix at the appropriate layer.
+  ov::Tensor beam_idx = ov::Tensor(ov::element::i32, {1});
+  std::fill_n(beam_idx.data<int32_t>(), 1, 0);
+  ovInfReq.set_tensor("beam_idx", beam_idx);
+
+  // If 'prefill full chat history' mode is enabled, we need to cache input_ids and position_ids.
+  if (prefill_use_full_chat_history) {
+    auto input_ids_tensor = ovInfReq.get_tensor("input_ids");
+
+    // Cache the "input_ids" tensor
+    {
+      auto* pData = input_ids_tensor.data<int64_t>();
+      for (size_t i = 0; i < input_ids_tensor.get_size(); i++) {
+        cached_input_ids.push_back(pData[i]);
+      }
+    }
+
+    // Cache the "position_ids" tensor
+    {
+      auto position_ids = ovInfReq.get_tensor("position_ids");
+      auto* pData = position_ids.data<int64_t>();
+      for (size_t i = 0; i < position_ids.get_size(); i++) {
+        cached_position_ids.push_back(pData[i]);
+      }
+    }
+
+    // If we're about to run the prefill model
+    if (input_ids_tensor.get_size() > 1) {
+      // Check if the size of the current "input_ids" tensor does not match the size of the cached "input_ids".
+      // This indicates that we are running a subsequent prompt (not the initial prefill).
+      if (input_ids_tensor.get_shape()[1] != cached_input_ids.size()) {
+        // Clear the internal KVCache state. For NPU device, this operation is a no-op.
+        ovInfReq.reset_state();
+
+        // Create and set a new "input_ids" tensor using the cached "input_ids" values.
+        {
+          auto new_shape = input_ids_tensor.get_shape();
+          new_shape[1] = cached_input_ids.size();
+          auto new_input_ids = ov::Tensor(input_ids_tensor.get_element_type(), new_shape);
+          auto* pNewInputIds = new_input_ids.data<int64_t>();
+          std::memcpy(pNewInputIds, cached_input_ids.data(), cached_input_ids.size() * sizeof(int64_t));
+          ovInfReq.set_tensor("input_ids", new_input_ids);
+        }
+
+        // Create and set a new "position_ids" tensor using the cached "position_ids" values.
+        {
+          auto position_ids_tensor = ovInfReq.get_tensor("position_ids");
+          auto new_shape = position_ids_tensor.get_shape();
+          new_shape[1] = cached_position_ids.size();
+          auto new_position_ids = ov::Tensor(position_ids_tensor.get_element_type(), new_shape);
+          auto* pNewPositionIds = new_position_ids.data<int64_t>();
+          std::memcpy(pNewPositionIds, cached_position_ids.data(), cached_position_ids.size() * sizeof(int64_t));
+          ovInfReq.set_tensor("position_ids", new_position_ids);
+        }
+      }
+    }
+  }
+}
+
+void StatefulOVInferRequest::StartAsync() {
+  PreProcessInferRequest();
+  OVInferRequest::StartAsync();
+}
+
+void StatefulOVInferRequest::Infer() {
+  PreProcessInferRequest();
+  OVInferRequest::Infer();
+}
+
+void StatefulOVInferRequest::RewindKVCache(size_t index) {
+  LOGS_DEFAULT(INFO) << log_tag << "RewindKVCache: Rewinding OpenVINO-internal KVCache state to index=" << index;
+
+  if (prefill_use_full_chat_history) {
+    // Clear the internal KVCache state. For NPU device, this operation is a no-op.
+    ovInfReq.reset_state();
+
+    // Resize the cached "input_ids" and "position_ids" to the specified index.
+    if (cached_input_ids.size() > index) {
+      cached_input_ids.resize(index);
+    }
+
+    if (cached_position_ids.size() > index) {
+      cached_position_ids.resize(index);
+    }
+  } else {
+    if (index == 0) {
+      // In this case, since we're resetting the entire KVCache, simply reset the state.
+      ovInfReq.reset_state();
+    } else {
+      // Retrieve KVCache states and trim them to the specified index.
+      // The following logic is adapted from:
+      // https://github.com/openvinotoolkit/openvino.genai/blob/releases/2025/1/src/cpp/src/utils.cpp#L329
+      auto states = ovInfReq.query_state();
+      for (auto& state : states) {
+        ov::Tensor old_tensor = state.get_state();
+        // Tensor shape: [batch_size, num_kv_heads, seq_len, head_size]
+        auto shape = old_tensor.get_shape();
+
+        if (shape[2] > index) {
+          // Update the sequence length dimension to the specified index.
+          shape[2] = index;
+
+          ov::Coordinate new_shape_begin{0, 0, 0, 0};
+          ov::Coordinate new_shape_end{shape};
+
+          // Create a trimmed tensor with the updated shape.
+          auto trimmed_tensor = ov::Tensor(old_tensor, new_shape_begin, new_shape_end);
+
+          // Copy the trimmed tensor into a new tensor and update the state.
+          ov::Tensor new_tensor(old_tensor.get_element_type(), shape);
+          trimmed_tensor.copy_to(new_tensor);
+
+          state.set_state(new_tensor);
+        }
+      }
+    }
+  }
+}
+
 }  // namespace openvino_ep
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -72,10 +72,14 @@ struct OVCore : WeakSingleton<OVCore> {
   // OV Interface For Reading Model
   std::shared_ptr<OVNetwork> ReadModel(std::string&& model_stream, const std::string& model_path);
 
+  OVExeNetwork StatefulCompileModel(std::shared_ptr<OVNetwork>& model,
+                                    std::string& hw_target,
+                                    const ov::AnyMap& device_config);
   // OV Interface for Compiling OV Model Type
   OVExeNetwork CompileModel(std::shared_ptr<const OVNetwork>& ie_cnn_network,
                             std::string& hw_target,
                             ov::AnyMap& device_config,
+                            bool enable_causallm,
                             const std::string& name);
   // OV Interface for Fast Compile
   OVExeNetwork CompileModel(const std::string& onnx_model,
@@ -102,16 +106,20 @@ struct OVCore : WeakSingleton<OVCore> {
 };
 
 class OVExeNetwork {
-  ov::CompiledModel obj;
+  ov::CompiledModel compiled_model_obj;
+  std::string target_device;
+  bool is_stateful_causallm;
 
  public:
-  explicit OVExeNetwork(ov::CompiledModel md) : obj(md) {}
-  OVExeNetwork() : obj(ov::CompiledModel()) {}
-  ov::CompiledModel& Get() { return obj; }
-  OVInferRequest CreateInferRequest();
+  explicit OVExeNetwork(ov::CompiledModel compiled_model, std::string device, bool stateful_causallm = false)
+      : compiled_model_obj(compiled_model), target_device(device), is_stateful_causallm(stateful_causallm) {}
+  OVExeNetwork() : compiled_model_obj(ov::CompiledModel()) {}
+  ov::CompiledModel& Get() { return compiled_model_obj; }
+  std::shared_ptr<OVInferRequest> CreateInferRequest();
 };
 
 class OVInferRequest {
+ protected:
   ov::InferRequest ovInfReq;
 
  public:
@@ -119,15 +127,36 @@ class OVInferRequest {
   OVTensorPtr GetTensor(const std::string& name);
   std::string GetInputTensorName(uint32_t index);
   void SetTensor(const std::string& name, OVTensorPtr& blob);
-  void StartAsync();
-  void Infer();
+  virtual void StartAsync();
+  virtual void Infer();
   void WaitRequest();
   void QueryStatus();
-  explicit OVInferRequest(ov::InferRequest obj) : ovInfReq(std::move(obj)) {}
+  explicit OVInferRequest(ov::InferRequest infer_request_obj) : ovInfReq(std::move(infer_request_obj)) {}
   OVInferRequest() : ovInfReq(ov::InferRequest()) {}
   ov::InferRequest& GetNewObj() {
     return ovInfReq;
   }
+  virtual void RewindKVCache(size_t index) {};
 };
+
+class StatefulOVInferRequest : public OVInferRequest {
+ public:
+  explicit StatefulOVInferRequest(ov::InferRequest infer_request, std::string device);
+
+  void StartAsync() override;
+  void Infer() override;
+  void RewindKVCache(size_t index) override;
+
+ private:
+  void PreProcessInferRequest();
+  std::string target_device;
+
+  // If prefill_use_full_chat_history is true, cache the "input_ids" & "position_ids" tensors,
+  // and ensure that full chat history is passed for each prefill call.
+  bool prefill_use_full_chat_history = false;
+  std::vector<int64_t> cached_input_ids;
+  std::vector<int64_t> cached_position_ids;
+};
+
 }  // namespace openvino_ep
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/ov_stateful_patch_utils.cc
+++ b/onnxruntime/core/providers/openvino/ov_stateful_patch_utils.cc
@@ -1,0 +1,340 @@
+// Copyright (C) Intel Corporation
+// Licensed under the MIT License
+
+#include "ov_stateful_patch_utils.h"
+
+namespace onnxruntime {
+namespace openvino_ep {
+
+void LogBasicModelInfo(const std::shared_ptr<const ov::Model>& model) {
+  std::cout << "Model Name: " << model->get_friendly_name() << std::endl;
+
+  // Log detailed information about model inputs and outputs
+  auto inputs = model->inputs();
+  auto outputs = model->outputs();
+
+  std::cout << "\tInputs: " << std::endl;
+  for (const ov::Output<const ov::Node>& input : inputs) {
+    const std::string name = input.get_any_name();
+    const ov::element::Type type = input.get_element_type();
+    const ov::PartialShape shape = input.get_partial_shape();
+    const ov::Layout layout = ov::layout::get_layout(input);
+
+    std::cout << "\t\t" << name << ", " << type << ", " << shape << ", " << layout.to_string() << std::endl;
+  }
+
+  std::cout << "\tOutputs: " << std::endl;
+  for (const ov::Output<const ov::Node>& output : outputs) {
+    const std::string name = output.get_any_name();
+    const ov::element::Type type = output.get_element_type();
+    const ov::PartialShape shape = output.get_partial_shape();
+    const ov::Layout layout = ov::layout::get_layout(output);
+
+    std::cout << "\t\t" << name << ", " << type << ", " << shape << ", " << layout.to_string() << std::endl;
+  }
+
+  return;
+}
+
+bool ModelHasInputOutputNames(std::shared_ptr<ov::Model> model, const std::string& name_to_match) {
+  for (const ov::Output<ov::Node>& input : model->inputs()) {
+    auto& names = input.get_names();
+
+    for (auto& name : names) {
+      if (name == name_to_match) {
+        return true;
+      }
+    }
+  }
+
+  for (const ov::Output<ov::Node>& output : model->outputs()) {
+    auto& names = output.get_names();
+    for (auto& name : names) {
+      if (name == name_to_match) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+void FuseCacheReorder(std::shared_ptr<ov::Model> ov_model,
+                      std::vector<std::string>& not_kv_inputs,
+                      const std::vector<std::string>& key_value_input_names,
+                      int gather_dim) {
+  if (ModelHasInputOutputNames(ov_model, "beam_idx")) {
+    throw std::runtime_error("Model already has fused cache");
+  }
+
+  std::string main_input_name = "inputs_embeds";
+  if (ModelHasInputOutputNames(ov_model, "input_ids")) {
+    main_input_name = "input_ids";
+  }
+
+  auto input_batch = ov_model->input(main_input_name).get_partial_shape()[0];
+
+  auto beam_idx = std::make_shared<ov::opset13::Parameter>(ov::element::i32, ov::PartialShape({input_batch}));
+  beam_idx->set_friendly_name("beam_idx");
+  beam_idx->output(0).get_tensor().add_names({"beam_idx"});
+  ov_model->add_parameters({beam_idx});
+  not_kv_inputs.push_back(beam_idx->get_friendly_name());
+
+  // Go over all cache parameters and fuse _reorder_cache with indices provided by the new parameter beam_idx
+  for (const auto& input_name : key_value_input_names) {
+    auto parameter_output_port = ov_model->input(input_name);
+    auto consumers = parameter_output_port.get_target_inputs();
+
+    auto gather_op =
+        std::make_shared<ov::opset13::Gather>(parameter_output_port,
+                                              beam_idx,
+                                              ov::opset13::Constant::create(ov::element::i64, {}, {gather_dim}));
+
+    // Replace the source output for all consumers of the input tensor
+    for (auto& consumer : consumers) {
+      consumer.replace_source_output(gather_op->output(0));
+    }
+  }
+
+  // Validate the modified model
+  ov_model->validate_nodes_and_infer_types();
+}
+
+void MakeStateful(std::shared_ptr<ov::Model>& ov_model,
+                  const std::vector<std::string>& key_value_input_names,
+                  const std::vector<std::string>& key_value_output_names) {
+  std::map<std::string, std::string> input_output_map;
+
+  // Create mapping for KV-cache inputs and outputs
+  for (size_t i = 0; i < key_value_input_names.size(); ++i) {
+    input_output_map[key_value_input_names[i]] = key_value_output_names[i];
+  }
+
+  // Apply the transformation to make the model stateful
+  ov::pass::Manager manager;
+  manager.register_pass<ov::pass::MakeStateful>(input_output_map);
+  manager.run_passes(ov_model);
+}
+
+// Converted to C++ from below reference URL:
+// https://github.com/huggingface/optimum-intel/blob/main/optimum/exporters/openvino/stateful.py#L281
+void PatchStatefulDecoder(std::shared_ptr<ov::Model> model) {
+  std::vector<std::string> key_value_input_names;
+  std::vector<std::string> not_kv_inputs;
+  for (const ov::Output<ov::Node>& input : model->inputs()) {
+    auto& names = input.get_names();
+
+    bool found = false;
+    for (auto& name : names) {
+      if (name.find("key_values") != std::string::npos) {
+        key_value_input_names.push_back(name);
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      not_kv_inputs.push_back(input.get_any_name());
+    }
+  }
+
+  std::vector<std::string> key_value_output_names;
+  for (const ov::Output<ov::Node>& output : model->outputs()) {
+    auto& names = output.get_names();
+    for (auto& name : names) {
+      if (name.find("present") != std::string::npos) {
+        key_value_output_names.push_back(name);
+        break;
+      }
+    }
+  }
+
+  if (key_value_input_names.empty() || key_value_output_names.empty()) {
+    std::cout << "no key_value_input_names or key_value_output_names found" << std::endl;
+    return;
+  }
+
+  // By default, batch is the 0 - th but chatglm uses 1 - st dimension as batch
+  // TODO: Deduce from a model via ordinal reshape(? ) and topology
+  // batch_dim = 1 if config.model_type == "chatglm" and not hasattr(config, "rope_ratio") else 0
+  auto batch_dim = 0;
+
+  FuseCacheReorder(model, not_kv_inputs, key_value_input_names, batch_dim);
+
+  MakeStateful(model, key_value_input_names, key_value_output_names);
+}
+
+// Some other utility functions copied from OpenVINO GenAI
+bool HasOpWithType(const std::shared_ptr<const ov::Model>& function, const std::string& type_name) {
+  for (const auto& op : function->get_ops()) {
+    if (op->get_type_name() == type_name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::tuple<std::shared_ptr<ov::Node>, int64_t> FindLLMMatmul(const std::shared_ptr<ov::Model>& model) {
+  auto last_node = model->output(0).get_node()->input_value(0).get_node_shared_ptr();
+  std::shared_ptr<ov::Node> matmul = ov::as_type_ptr<ov::op::v0::MatMul>(last_node);
+
+  // In the case of PagedAttention, all tokens are moved to the batch dimension,
+  // and slicing/gathering must be performed accordingly.
+  const bool pa_based_model = HasOpWithType(model, "PagedAttentionExtension");
+  int64_t slice_gather_dim = pa_based_model ? 0 : 1;
+
+  // There are several patterns for MatMul we are looking for:
+  // MatMul -> Result
+  // MatMul -> Add -> Result
+  // MatMul -> Transpose -> Result
+  // MatMul -> Divide -> Tanh -> Multiply -> Result
+  if (!matmul) {
+    if (auto add = ov::as_type_ptr<ov::op::v1::Add>(last_node)) {
+      matmul = ov::as_type_ptr<ov::op::v0::MatMul>(add->input_value(0).get_node_shared_ptr());
+    } else if (auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(last_node)) {
+      matmul = ov::as_type_ptr<ov::op::v0::MatMul>(transpose->input_value(0).get_node_shared_ptr());
+      auto order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr())->get_axis_vector_val();
+      slice_gather_dim = order[slice_gather_dim];
+    } else if (auto multiply = ov::as_type_ptr<ov::op::v1::Multiply>(last_node)) {
+      if (auto tanh = ov::as_type_ptr<ov::op::v0::Tanh>(multiply->input_value(0).get_node_shared_ptr())) {
+        if (auto divide = ov::as_type_ptr<ov::op::v1::Divide>(tanh->input_value(0).get_node_shared_ptr())) {
+          matmul = ov::as_type_ptr<ov::op::v0::MatMul>(divide->input_value(0).get_node_shared_ptr());
+        }
+      }
+    }
+  }
+  return std::make_tuple(matmul, slice_gather_dim);
+}
+
+void ApplySliceBeforeMatmulTransformation(std::shared_ptr<ov::Model> model) {
+  std::shared_ptr<ov::Node> matmul = nullptr;
+  int64_t slice_gather_dim = -1;
+  std::tie(matmul, slice_gather_dim) = FindLLMMatmul(model);
+
+  if (matmul && matmul->input(0).get_partial_shape().rank().get_length() == 3) {
+    auto start = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
+    auto stop = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-2});
+    auto step = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
+    auto axis = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{slice_gather_dim});
+    auto slice = std::make_shared<ov::op::v8::Slice>(matmul->input_value(0), start, stop, step, axis);
+    matmul->input(0).replace_source_output(slice);
+  }
+}
+
+void UpdateConfig(ov::AnyMap& config, const std::pair<std::string, ov::Any>& pair) {
+  if (config.count(pair.first) == 0) {
+    config.insert(pair);
+  }
+}
+
+std::optional<ov::Any> PopOption(ov::AnyMap& config, const std::string& option_name) {
+  if (auto it = config.find(option_name); it != config.end()) {
+    std::optional<ov::Any> found = std::make_optional(it->second);
+    config.erase(it);
+    return found;
+  }
+  return std::nullopt;
+}
+
+void RenameKey(ov::AnyMap& config, const std::string& old_key, const std::string& new_key) {
+  if (config.count(old_key) != 0) {
+    auto opt_value = PopOption(config, old_key);
+    config[new_key] = opt_value.value();
+  }
+}
+
+KVAxesPosition GetKVAxesPos(std::shared_ptr<const ov::Model> model) {
+  // Sequence length axis in key/values tensors. For most cases, the tensor shape is
+  // [batch_size, num_kv_heads, seq_len, head_size]. Therefore, the sequence length axis
+  // is usually at index 2, and the batch axis is at index 0.
+  KVAxesPosition kv_pos{0u, 2u};
+
+  // "ReadValue" node is KV cache representation in stateful model
+  std::string kv_node_type_name = std::string(ov::op::v6::ReadValue::get_type_info_static().name);
+
+  for (const auto& op : model->get_ops()) {
+    // Check input size, as in LoRA adapters case it could be 0
+    if (op->get_type_name() != kv_node_type_name || op->get_input_size() < 1) {
+      continue;
+    }
+
+    // Shape example: [-1,4,0,64]
+    auto shape = op->get_input_partial_shape(0);
+
+    for (int64_t i = 0; i < shape.rank().get_length(); i++) {
+      // Find axis = 0. This would be sequence length axis.
+      if (shape[i] == 0) {
+        kv_pos.seq_len = i;
+      } else if (shape[i].is_dynamic()) {
+        // Dynamic axis is a batch
+        kv_pos.batch = i;
+      }
+    }
+    break;
+  }
+
+  return kv_pos;
+}
+
+void UpdateNPUConfig(ov::AnyMap& config, const KVAxesPosition& kv_pos, const KVDesc& kv_desc) {
+  UpdateConfig(config, {"NPU_USE_NPUW", "YES"});
+  UpdateConfig(config, {"NPUW_LLM", "YES"});
+
+  UpdateConfig(config, {"NPUW_LLM_BATCH_DIM", kv_pos.batch});
+  UpdateConfig(config, {"NPUW_LLM_SEQ_LEN_DIM", kv_pos.seq_len});
+
+  UpdateConfig(config, {"NPUW_LLM_MAX_PROMPT_LEN", kv_desc.max_prompt_len});
+  UpdateConfig(config, {"NPUW_LLM_MIN_RESPONSE_LEN", kv_desc.min_response_len});
+
+  RenameKey(config, "++PREFILL_CONFIG", "++NPUW_LLM_PREFILL_CONFIG");
+  RenameKey(config, "++GENERATE_CONFIG", "++NPUW_LLM_GENERATE_CONFIG");
+  RenameKey(config, "PREFILL_CONFIG", "NPUW_LLM_PREFILL_CONFIG");
+  RenameKey(config, "PREFILL_HINT", "NPUW_LLM_PREFILL_HINT");
+  RenameKey(config, "GENERATE_CONFIG", "NPUW_LLM_GENERATE_CONFIG");
+  RenameKey(config, "GENERATE_HINT", "NPUW_LLM_GENERATE_HINT");
+}
+
+std::optional<ov::Any> PopOptionNew(ov::AnyMap& config, const std::string& option_name) {
+  if (auto it = config.find(option_name); it != config.end()) {
+    std::optional<ov::Any> found = std::make_optional(it->second);
+    config.erase(it);
+    return found;
+  }
+  return std::nullopt;
+}
+
+std::optional<uint32_t> PopIntAndCast(ov::AnyMap& config, const std::string& key) {
+  auto anyopt = PopOptionNew(config, key);
+  if (anyopt.has_value()) {
+    const auto any = anyopt.value();
+    int64_t value;
+    // NB: Integer value coming from python has int64_t datatype
+    if (any.is<int64_t>()) {
+      value = any.as<int64_t>();
+    } else if (any.is<int>()) {
+      value = any.as<int>();
+    } else {
+      OPENVINO_THROW("Failed to extract " + key + ". Type mismatch: expected types: int or int64_t");
+    }
+    if (value < 0) {
+      OPENVINO_THROW(key + " cannot be negative!");
+    }
+    return std::make_optional(static_cast<uint32_t>(value));
+  }
+  return std::nullopt;
+}
+
+bool IsStateful(const std::shared_ptr<ov::Model>& model) {
+  for (auto&& ptr : model->get_ordered_ops()) {
+    if (ov::is_type<ov::op::v3::ReadValue>(ptr) ||
+        ov::is_type<ov::op::v6::ReadValue>(ptr) ||
+        ov::is_type<ov::op::v3::Assign>(ptr) ||
+        ov::is_type<ov::op::v6::Assign>(ptr)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace openvino_ep
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/openvino/ov_stateful_patch_utils.h
+++ b/onnxruntime/core/providers/openvino/ov_stateful_patch_utils.h
@@ -1,0 +1,84 @@
+// Copyright (C) Intel Corporation
+// Licensed under the MIT License
+
+#pragma once
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "openvino/pass/manager.hpp"
+#include "openvino/pass/make_stateful.hpp"
+#include "openvino/opsets/opset13.hpp"
+
+namespace onnxruntime {
+namespace openvino_ep {
+
+void LogBasicModelInfo(const std::shared_ptr<const ov::Model>& model);
+
+bool ModelHasInputOutputNames(std::shared_ptr<ov::Model> model, const std::string& name_to_match);
+
+void FuseCacheReorder(std::shared_ptr<ov::Model> ov_model,
+                      std::vector<std::string>& not_kv_inputs,
+                      const std::vector<std::string>& key_value_input_names,
+                      int gather_dim);
+
+void MakeStateful(std::shared_ptr<ov::Model>& ov_model,
+                  const std::vector<std::string>& key_value_input_names,
+                  const std::vector<std::string>& key_value_output_names);
+
+void PatchStatefulDecoder(std::shared_ptr<ov::Model> model);
+
+bool HasOpWithType(const std::shared_ptr<const ov::Model>& function, const std::string& type_name);
+
+std::tuple<std::shared_ptr<ov::Node>, int64_t> FindLLMMatmul(const std::shared_ptr<ov::Model>& model);
+
+void ApplySliceBeforeMatmulTransformation(std::shared_ptr<ov::Model> model);
+
+void UpdateConfig(ov::AnyMap& config, const std::pair<std::string, ov::Any>& pair);
+
+std::optional<ov::Any> PopOption(ov::AnyMap& config, const std::string& option_name);
+
+void RenameKey(ov::AnyMap& config, const std::string& old_key, const std::string& new_key);
+
+struct KVAxesPosition {
+  size_t batch;
+  size_t seq_len;
+};
+
+KVAxesPosition GetKVAxesPos(std::shared_ptr<const ov::Model> model);
+
+struct KVDesc {
+  uint32_t max_prompt_len;
+  uint32_t min_response_len;
+};
+
+struct CausalLMConfig {
+  void ApplyConfig(const ov::AnyMap& external_config, ov::AnyMap& genai_config) {
+    if (external_config.find("MAX_PROMPT_LEN") != external_config.end()) {
+      max_prompt_len = external_config.at("MAX_PROMPT_LEN").as<unsigned int>();
+    }
+    if (external_config.find("MIN_RESPONSE_LEN") != external_config.end()) {
+      min_response_len = external_config.at("MIN_RESPONSE_LEN").as<unsigned int>();
+    }
+    genai_config["MAX_PROMPT_LEN"] = ov::Any(max_prompt_len);
+    genai_config["MIN_RESPONSE_LEN"] = ov::Any(min_response_len);
+  }
+
+  unsigned int max_prompt_len = 1024;
+  unsigned int min_response_len = 128;
+};
+
+void UpdateNPUConfig(ov::AnyMap& config, const KVAxesPosition& kv_pos, const KVDesc& kv_desc);
+
+std::optional<ov::Any> PopOptionNew(ov::AnyMap& config, const std::string& option_name);
+std::optional<uint32_t> PopIntAndCast(ov::AnyMap& config, const std::string& key);
+
+bool IsStateful(const std::shared_ptr<ov::Model>& model);
+
+}  // namespace openvino_ep
+}  // namespace onnxruntime

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -747,6 +747,15 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
         } else {
           ORT_THROW("[ERROR] [OpenVINO] The value for the key 'enable_qdq_optimizer' should be a boolean i.e. true or false. Default value is false.\n");
         }
+      } else if (key == "enable_causallm") {
+        if (value == "true" || value == "True" ||
+            value == "false" || value == "False") {
+          ov_options[key] = value;
+        } else {
+          ORT_THROW(
+              "[ERROR] [OpenVINO] The value for the key 'enable_causallm' should be a boolean i.e. true or false."
+              " Default value is false. This provider option must be used with CausalLM Models viz. LLMs & SLMs only.\n");
+        }
       } else if (key == "disable_dynamic_shapes") {
         if (value == "true" || value == "True" ||
             value == "false" || value == "False") {
@@ -804,7 +813,8 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
         ORT_THROW(
             "[ERROR] [OpenVINO] wrong key type entered. Choose from the following runtime key options that are available for OpenVINO."
             " ['device_type', 'device_id', 'num_of_threads', 'load_config', 'cache_dir', 'num_streams', "
-            "'enable_opencl_throttling', 'disable_dynamic_shapes', 'enable_qdq_optimizer', 'model_priority'] \n");
+            "'enable_opencl_throttling', 'disable_dynamic_shapes', 'enable_qdq_optimizer',"
+            " 'enable_causallm', 'model_priority'] \n");
       }
     }
     session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);


### PR DESCRIPTION
### Description
This PR enables  the essential features to enable ORT GenAI with OVEP using Stateful Compilation of ov::Model, inspired from OV GenAI pipeline flow.

I have introduced a new provider option `enable_causallm` which can be set to `True` for enabling the ORT GenAI pipeline with Causal LLM _Models that are fully supported on OVEP_ in the custom config file called _genai_config.json_ 

Sample _genai_config.json_ -

```
"provider_options": [
    {
         // Key "OpenVINO" is case sensitive and must be used as below as its defined by MSFT
         "OpenVINO":
          {
              "device_type": "NPU",
              "enable_causallm" : "True",
              // (Applicable for NPU only) Optional setting for compilation with custom MAX_PROMPT_LEN & MIN_RESPONSE_LEN
              "load_config": "{\"NPU\":{\"MAX_PROMPT_LEN\":\"2048\",\"MIN_RESPONSE_LEN\":\"512\"}}"                            
                       
           }
    }
    ]
```          
FYI the GenAI models in ONNX format are usually Stateless in nature & require dynamic shapes compilation.



