### PR TITLE
Don't include initializers in compute capability

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -126,9 +126,6 @@ std::vector<std::unique_ptr<ComputeCapability>> GetCapability::Execute() {
       }
     }
 
-    // Initializers need to be part of meta_def->inputs
-    Iterable2String(inputs, ng_required_initializers);
-
     // Fill outputs with names
     Iterable2String(outputs, graph_viewer_.GetOutputs());
 


### PR DESCRIPTION
Today we return initializers as inputs to our compute capability. The results in ORT loading those initializers during inference, however, we don't need those initializers as they will be internal to our ov model.

This significantly improves inference performance + memory for non-ep context models.