### PR TITLE
 Support workload type for dynamic shaped models

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -28,9 +28,10 @@ SessionContext& BackendManager::GetSessionContext() {
   return session_context_;
 }
 
-ov::CompiledModel& BackendManager::GetOVCompiledModel() {
-  ov::CompiledModel& ov_ptr = concrete_backend_->GetOVCompiledModel();
-  return (ov_ptr);
+ov::CompiledModel BackendManager::GetOVCompiledModel() {
+  if (concrete_backend_)
+    return concrete_backend_->GetOVCompiledModel();
+  return ov::CompiledModel();
 }
 
 BackendManager::BackendManager(SessionContext& session_context,

--- a/onnxruntime/core/providers/openvino/backend_manager.h
+++ b/onnxruntime/core/providers/openvino/backend_manager.h
@@ -29,7 +29,7 @@ class BackendManager {
   void ShutdownBackendManager();
   SessionContext& GetSessionContext();
   Status ExportCompiledBlobAsEPCtxNode(const onnxruntime::GraphViewer& subgraph);
-  ov::CompiledModel& GetOVCompiledModel();
+  ov::CompiledModel GetOVCompiledModel();
 
  private:
   std::unique_ptr<ONNX_NAMESPACE::ModelProto> GetModelProtoFromFusedNode(

--- a/onnxruntime/core/providers/openvino/backends/basic_backend.h
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.h
@@ -38,7 +38,7 @@ class BasicBackend : public IBackend {
 
   void Infer(OrtKernelContext* context) override;
   ~BasicBackend() override = default;
-  ov::CompiledModel& GetOVCompiledModel() override {
+  ov::CompiledModel GetOVCompiledModel() override {
     return exe_network_.Get();
   }
 

--- a/onnxruntime/core/providers/openvino/ibackend.h
+++ b/onnxruntime/core/providers/openvino/ibackend.h
@@ -15,7 +15,7 @@ namespace openvino_ep {
 class IBackend {
  public:
   virtual void Infer(OrtKernelContext* context) = 0;
-  virtual ov::CompiledModel& GetOVCompiledModel() = 0;
+  virtual ov::CompiledModel GetOVCompiledModel() = 0;
   virtual ~IBackend() = default;
 };
 using ptr_stream_t = std::unique_ptr<std::istream>;


### PR DESCRIPTION
### Description
Workload_type property can be set past model compilation in OV. 

This feature allows us to set the property for NPU on a dynamically shaped model at runtime. 

