### PR TITLE
[GPU] Enable qdq_stripping path for GPU

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -381,7 +381,8 @@ BackendManager::GetModelProtoFromFusedNode(const onnxruntime::Node& fused_node,
 
   const auto& onnx_model_path_name = subgraph.ModelPath();
   // QDQ stripping enabled only for the NPU
-  if (session_context_.device_type.find("NPU") != std::string::npos &&
+  if ((session_context_.device_type.find("NPU") != std::string::npos ||
+      session_context_.device_type.find("GPU") != std::string::npos) &&
       (enable_ovep_qdq_optimizer || session_context_.so_share_ep_contexts)) {
     std::unique_ptr<onnxruntime::Model> model;
     Status status = CreateModelWithStrippedQDQNodes(subgraph, logger, session_context_.so_share_ep_contexts, enable_ovep_qdq_optimizer, model, shared_context_.shared_weights);


### PR DESCRIPTION
Try enabling enable_qdq_optimizer  for the GPU device

### Description
Update the conditions so that we can run CreateModelWithStrippedQDQNodes for the GPU device

### Motivation and Context
Implementation for https://jira.devtools.intel.com/browse/CVS-167484


