### PR TITLE
Improve the condition for device=GPU and qdq stripping enabled

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -38,8 +38,7 @@ GetCapability::GetCapability(const EPCtxHandler& ep_ctx_handler,
     device_type_ = "CPU";
     if (enable_qdq_optimizer) npu_qdq_optimizer_enabled = true;
   } else if (enable_qdq_optimizer && device_type_.find("GPU") != std::string::npos) {
-    npu_qdq_optimizer_enabled = true;
-    // device_type_ = "CPU"; // change in questio
+    npu_qdq_optimizer_enabled = true;   // see data_ops.cc ~615 where we check for int16 types for gpu, this may change to a better approach later
   }
 
 #if OPENVINO_VERSION_MAJOR == 2024 && OPENVINO_VERSION_MINOR == 5

--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -39,7 +39,7 @@ GetCapability::GetCapability(const EPCtxHandler& ep_ctx_handler,
     if (enable_qdq_optimizer) npu_qdq_optimizer_enabled = true;
   } else if (enable_qdq_optimizer && device_type_.find("GPU") != std::string::npos) {
     npu_qdq_optimizer_enabled = true;
-    device_type_ = "CPU";
+    // device_type_ = "CPU"; // change in questio
   }
 
 #if OPENVINO_VERSION_MAJOR == 2024 && OPENVINO_VERSION_MINOR == 5

--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -34,10 +34,14 @@ GetCapability::GetCapability(const EPCtxHandler& ep_ctx_handler,
                                                                 graph_viewer_(graph_viewer_param),
                                                                 device_type_(std::move(device_type_param)) {
   bool npu_qdq_optimizer_enabled = false;
-  if (device_type_.find("NPU") != std::string::npos || device_type_.find("GPU") != std::string::npos) {
+  if (device_type_.find("NPU") != std::string::npos) {
     device_type_ = "CPU";
     if (enable_qdq_optimizer) npu_qdq_optimizer_enabled = true;
+  } else if (enable_qdq_optimizer && device_type_.find("GPU") != std::string::npos) {
+    npu_qdq_optimizer_enabled = true;
+    device_type_ = "CPU";
   }
+
 #if OPENVINO_VERSION_MAJOR == 2024 && OPENVINO_VERSION_MINOR == 5
   data_ops_ = new DataOps(graph_viewer_, V_2024_5, device_type_, npu_qdq_optimizer_enabled);
 #elif OPENVINO_VERSION_MAJOR == 2024 && OPENVINO_VERSION_MINOR == 6

--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -612,6 +612,9 @@ bool DataOps::type_is_supported(const NodeArg* node_arg, bool is_initializer) {
             (var.second == dtype)) {
           return true;
         }
+        // experimentally for GPU and qdq stripping mode allow int16 types
+        if (npu_qdq_optimizer_enabled_ && (dtype == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT16 || dtype == ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_UINT16))
+            return true;
       }
 #ifndef NDEBUG
       if (openvino_ep::backend_utils::IsDebugEnabled()) {

--- a/onnxruntime/test/perftest/main.cc
+++ b/onnxruntime/test/perftest/main.cc
@@ -7,8 +7,6 @@
 #include "command_args_parser.h"
 #include "performance_runner.h"
 #include <google/protobuf/stubs/common.h>
-#define WINDOWS_LEAN_AND_MEAN
-#include <windows.h>
 
 using namespace onnxruntime;
 const OrtApi* g_ort = NULL;
@@ -68,8 +66,6 @@ int wmain(int argc, wchar_t* argv[]) {
 #else
 int main(int argc, char* argv[]) {
 #endif
-  ::MessageBox(NULL, "Hello", "Hello", MB_OK);
-
   int retval = -1;
   ORT_TRY {
     retval = real_main(argc, argv);

--- a/onnxruntime/test/perftest/main.cc
+++ b/onnxruntime/test/perftest/main.cc
@@ -7,6 +7,8 @@
 #include "command_args_parser.h"
 #include "performance_runner.h"
 #include <google/protobuf/stubs/common.h>
+#define WINDOWS_LEAN_AND_MEAN
+#include <windows.h>
 
 using namespace onnxruntime;
 const OrtApi* g_ort = NULL;
@@ -66,6 +68,8 @@ int wmain(int argc, wchar_t* argv[]) {
 #else
 int main(int argc, char* argv[]) {
 #endif
+  ::MessageBox(NULL, "Hello", "Hello", MB_OK);
+
   int retval = -1;
   ORT_TRY {
     retval = real_main(argc, argv);


### PR DESCRIPTION
### Description
The code changed the caps device type to CPU no matter the status of qdq stripping flag. Now it's improved.



### Motivation and Context
Relates and fixes: CVS-169099


