### PR TITLE
Added to remove MAC CI Warnings

### DIFF
--- a/onnxruntime/test/perftest/performance_runner.cc
+++ b/onnxruntime/test/perftest/performance_runner.cc
@@ -218,6 +218,7 @@ Status PerformanceRunner::RunParallelDuration() {
 
   // Join
   tpool->Schedule([this, &counter, &m, &cv]() {
+    ORT_UNUSED_PARAMETER(this);
     std::unique_lock<std::mutex> lock(m);
     cv.wait(lock, [&counter]() { return counter == 0; });
   });


### PR DESCRIPTION
### Description
Some MAC OS CI warnings flagged this as UNUSED PARAMETER



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


