### PR TITLE
Allow zero-element tensors to get set

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_interface.h
+++ b/onnxruntime/core/providers/openvino/ov_interface.h
@@ -133,6 +133,22 @@ class OVInferRequest {
       auto tensor_ptr = std::make_shared<ov::Tensor>(type, shape, const_cast<void*>(ort_ptr));
       SetTensor(name, tensor_ptr);
       cached_binding = {tensor_ptr, ort_ptr};
+    } else if (ort_ptr==nullptr) {
+      // a null ort_ptr is expected for a tensor that has 0 elements.
+      // for example, a tensor of shape=[1, 8, 0, 64], which is valid.
+      // So, we check to see if at least one shape entry is 0.
+      auto contains_zero = [](const ov::Shape& shape) {
+        for (auto& s : shape)
+          if (s == 0) return true;
+        return false;
+      };
+      if (contains_zero(shape)) {
+        // if there are zero elements (i.e. at least one shape entry is 0),
+        // then create and set the tensor anyway.
+        auto tensor_ptr = std::make_shared<ov::Tensor>(type, shape);
+        SetTensor(name, tensor_ptr);
+        cached_binding = {tensor_ptr, ort_ptr};
+      }
     }
   }
 


### PR DESCRIPTION
### Description
This PR fixes an issue where zero-element tensors (typically when ort_ptr is nullptr) are not properly converted to OpenVINO tensors and set on the infer request. 



### Motivation and Context
For ORT GenAI use cases, it's possible that the application will pass zero-element tensors as input for inference. For example, for whisper pipeline through ORT GenAI, the first decode inference will set a 'past' KVCache tensor of shape `[1, 8, 0, 64]`. As this has 0 total elements, typically the ort_ptr associated with it is also nullptr. 

Previously, this condition (`if (cached_binding.ort_ptr != ort_ptr) {`) needed to be true in order to create an ov::Tensor and set it on the infer request. But, for a zero-element tensor, both of these are NULL and so the tensor does not get set -- which causes various issues.

This PR adds an else that specifically checks for this 'zero-element' tensor case. 

With this PR, I am able to run onnxruntime-genai whisper pipelines with OVEP.

**Note:** I didn't want to overcomplicate this PR, but I do think that this function should get revisited / refactored a bit. Comparing *only* the ptr is quite dangerous. For example, it's possible that the application can create a different shaped Ort tensor from the same buffer location -- so I think we should at least compared the ptr **and** the shape...


