### PR TITLE
Cluster Change to avoid Dangling DQLinear

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_versions/capability.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/capability.cc
@@ -206,7 +206,7 @@ std::vector<std::unique_ptr<ComputeCapability>> GetCapability::Execute() {
                                 cluster_inputs,
                                 cluster_outputs);
 
-      bool omit_subgraph = false;
+
       // Omitting zero dim subgraphs
       for (auto index : this_cluster) {
         const Node* node = graph_viewer_.GetNode(index);


### PR DESCRIPTION
### Description
Add dangling node of current cluster in next cluster. 



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


