### PR TITLE
[OVEP] Remove checks from load_config

### DIFF
--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
@@ -274,31 +274,14 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
       return devices;
     };
 
-    // Check if a property is supported and mutable
-    auto is_supported_and_mutable = [&](const std::string& key,
-                                        const std::vector<ov::PropertyName>& supported_config) -> bool {
-      auto it = std::find_if(supported_config.begin(), supported_config.end(), [&](const ov::PropertyName& property) {
-        return property == key && property.is_mutable();
-      });
-      return it != supported_config.end();
-    };
-
-    // Set properties if they are valid, else log a warning if the property is missing or immutable by skipping the same
-    auto set_target_properties = [&](const std::string& device, const ov::AnyMap& config_options,
-                                     const std::vector<ov::PropertyName>& supported_properties) {
+    // Set properties, Validation will be handled by OpenVINO Core
+    auto set_target_properties = [&](const std::string& device, const ov::AnyMap& config_options) {
       for (const auto& [key, value] : config_options) {
         if ((key.find("NPUW") != std::string::npos) ||
             ((device_config.find(key) != device_config.end()) && session_context_.enable_causallm)) {
           continue;
         }
-        if (is_supported_and_mutable(key, supported_properties)) {
-          OVCore::Get()->core.set_property(device, ov::AnyMap{{key, value}});
-        } else {
-          LOGS_DEFAULT(WARNING) << "WARNING: Property \"" << key
-                                << "\" is either unsupported in current OpenVINO version"
-                                << " or property is immutable for target device \""
-                                << device << "\". Skipping setting this property.";
-        }
+        OVCore::Get()->core.set_property(device, ov::AnyMap{{key, value}});
       }
     };
 
@@ -317,18 +300,14 @@ void BasicBackend::PopulateConfigValue(ov::AnyMap& device_config) {
       // Set properties only for individual devices (e.g., "CPU", "GPU")
       for (const std::string& device : individual_devices) {
         if (target_config.count(device)) {
-          // Get supported properties for each individual device
-          auto device_properties = OVCore::Get()->core.get_property(device, ov::supported_properties);
           // Set properties for the device
-          set_target_properties(device, target_config.at(device), device_properties);
+          set_target_properties(device, target_config.at(device));
         }
       }
     } else {
       if (target_config.count(session_context_.device_type)) {
-        auto supported_properties = OVCore::Get()->core.get_property(session_context_.device_type,
-                                                                     ov::supported_properties);
         set_target_properties(session_context_.device_type,
-                              target_config.at(session_context_.device_type), supported_properties);
+                              target_config.at(session_context_.device_type));
       }
     }
   }


### PR DESCRIPTION
This pr removes the "supported properties" validation check from load_config implementation. In case user passes a wrong or an immutable property OV will throw an error.


