### PR TITLE
[Draft] Add SetDataType method for Tensor objects

### DIFF
--- a/include/onnxruntime/core/framework/data_types.h
+++ b/include/onnxruntime/core/framework/data_types.h
@@ -934,6 +934,10 @@ class PrimitiveDataTypeBase : public DataTypeImpl {
     return nullptr;
   }
 
+  void SetDataType(ONNX_NAMESPACE::TensorProto_DataType data_type) {
+    *const_cast<int32_t*>(&data_type_) = data_type;
+  }
+
   int32_t GetDataType() const {
     return data_type_;
   }

--- a/include/onnxruntime/core/framework/tensor.h
+++ b/include/onnxruntime/core/framework/tensor.h
@@ -162,6 +162,13 @@ class Tensor final {
   MLDataType DataType() const { return dtype_; }
 
   /**
+     Sets the data type to an enum constant
+  */
+  void SetElementType(ONNX_NAMESPACE::TensorProto_DataType data_type) {
+    const_cast<PrimitiveDataTypeBase*>(dtype_)->SetDataType(data_type);
+  }
+
+  /**
      Returns the data type enum constant
      @remarks Use utils::ToTensorProtoElementType<T> for comparison.
   */

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -1290,6 +1290,7 @@ struct ProviderHost {
   virtual ptrdiff_t Tensor__ByteOffset(const Tensor* p) = 0;
   virtual size_t Tensor__SizeInBytes(const Tensor* p) = 0;
   virtual const OrtMemoryInfo& Tensor__Location(const Tensor* p) = 0;
+  virtual void Tensor__SetElementType(Tensor* p, ONNX_NAMESPACE::TensorProto_DataType data_type) = 0;
   virtual int32_t Tensor__GetElementType(const Tensor* p) = 0;
   virtual MLDataType Tensor__DataType(const Tensor* p) = 0;
 #ifdef ENABLE_STRIDED_TENSORS

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -1448,6 +1448,7 @@ struct Tensor final {
   const OrtMemoryInfo& Location() const { return g_host->Tensor__Location(this); }
 
   int32_t GetElementType() const { return g_host->Tensor__GetElementType(this); }
+  void SetElementType(ONNX_NAMESPACE::TensorProto_DataType data_type) { g_host->Tensor__SetElementType(this, data_type); }
   MLDataType DataType() const { return g_host->Tensor__DataType(this); }
   bool IsDataTypeString() const { return g_host->Tensor__IsDataTypeString(this); }
 

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1651,6 +1651,7 @@ struct ProviderHostImpl : ProviderHost {
   ptrdiff_t Tensor__ByteOffset(const Tensor* p) override { return p->ByteOffset(); }
   size_t Tensor__SizeInBytes(const Tensor* p) override { return p->SizeInBytes(); }
   const OrtMemoryInfo& Tensor__Location(const Tensor* p) override { return p->Location(); }
+  void Tensor__SetElementType(Tensor* p, ONNX_NAMESPACE::TensorProto_DataType data_type) override { p->SetElementType(data_type); }
   int32_t Tensor__GetElementType(const Tensor* p) override { return p->GetElementType(); }
   MLDataType Tensor__DataType(const Tensor* p) override { return p->DataType(); }
 #ifdef ENABLE_STRIDED_TENSORS


### PR DESCRIPTION
After recent changes in upstream onnxruntime, changing data type of TensorProto object no longer works, since the resulting data type is gathered from an OrtValue.

This fix allows to work around this issue. Since it's a core portion of onnxruntime, it's pending approval from Microsoft and it might be a better idea to merge it directly rather than via OVEP release.

Keeping it as a draft PR for tracking purposes until the decision is made.