### PR TITLE
Re-enable setting default precision for OV devices

### DIFF
--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -224,9 +224,7 @@ static void ParseProviderInfo(const ProviderOptions& provider_options,
     pi.cache_dir = provider_options.at("cache_dir");
   }
 
-  if (provider_options.contains("precision")) {
-    pi.precision = OpenVINOParserUtils::ParsePrecision(provider_options, pi.device_type, "precision");
-  }
+  pi.precision = OpenVINOParserUtils::ParsePrecision(provider_options, pi.device_type, "precision");
 
   if (provider_options.contains("reshape_input")) {
     pi.reshape = OpenVINOParserUtils::ParseInputShape(provider_options.at("reshape_input"));


### PR DESCRIPTION
### Description
Remove check for provider option :  precision 



