### PR TITLE
Fix onnxruntime 0D tensor issue on openvino endpoint

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -6580,6 +6580,17 @@ struct OrtApi {
                   _In_ size_t byte_size, _Outptr_ OrtExternalInitializerInfo** out);
 
   /// @}
+  /// \name OrtTensorTypeAndShapeInfo
+  /// @{
+
+  /** \brief Get the attribute `has_shape` from ::OrtTensorTypeAndShapeInfo object
+   *
+   * \param[out] out Returns bool
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   */
+  ORT_API2_STATUS(GetHasShape, _In_ const OrtTensorTypeAndShapeInfo* info, _Out_ bool* out);
+  /// @}
 };
 
 /*

--- a/include/onnxruntime/core/session/onnxruntime_cxx_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_api.h
@@ -1768,6 +1768,7 @@ struct TensorTypeAndShapeInfoImpl : Base<T> {
   void GetSymbolicDimensions(const char** values, size_t values_count) const;  ///< Wraps OrtApi::GetSymbolicDimensions
   std::vector<const char*> GetSymbolicDimensions() const;
 
+  bool GetHasShape() const;             ///< Wraps OrtApi::GetHasShape
   std::vector<int64_t> GetShape() const;  ///< Uses GetDimensionsCount & GetDimensions to return a std::vector of the shape
 };
 

--- a/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
+++ b/include/onnxruntime/core/session/onnxruntime_cxx_inline.h
@@ -1983,6 +1983,13 @@ inline size_t TensorTypeAndShapeInfoImpl<T>::GetElementCount() const {
 }
 
 template <typename T>
+inline bool TensorTypeAndShapeInfoImpl<T>::GetHasShape() const {
+  bool out;
+  ThrowOnError(GetApi().GetHasShape(this->p_, &out));
+  return static_cast<bool>(out);
+}
+
+template <typename T>
 inline size_t TensorTypeAndShapeInfoImpl<T>::GetDimensionsCount() const {
   size_t out;
   ThrowOnError(GetApi().GetDimensionsCount(this->p_, &out));

--- a/onnxruntime/core/framework/onnxruntime_typeinfo.cc
+++ b/onnxruntime/core/framework/onnxruntime_typeinfo.cc
@@ -170,7 +170,7 @@ std::unique_ptr<OrtTypeInfo> OrtTypeInfo::FromOrtValue(const OrtValue& value) {
     const Tensor& tensor = value.Get<onnxruntime::Tensor>();
     const auto* tensor_data_type = tensor.DataType();
     if (tensor_data_type != nullptr) {
-      auto type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(tensor.Shape(), *tensor_data_type);
+      auto type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(tensor.Shape(), *tensor_data_type, true);
       return MakePtr(ONNX_TYPE_TENSOR, std::move(type_shape));
     }
     return MakePtr(ONNX_TYPE_TENSOR);
@@ -181,7 +181,7 @@ std::unique_ptr<OrtTypeInfo> OrtTypeInfo::FromOrtValue(const OrtValue& value) {
     const SparseTensor& tensor = value.Get<onnxruntime::SparseTensor>();
     const auto* tensor_data_type = tensor.DataType();
     if (tensor_data_type != nullptr) {
-      auto type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(tensor.DenseShape(), *tensor_data_type);
+      auto type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(tensor.DenseShape(), *tensor_data_type, true);
       return MakePtr(ONNX_TYPE_SPARSETENSOR, std::move(type_shape));
     }
     return MakePtr(ONNX_TYPE_SPARSETENSOR);
@@ -195,7 +195,7 @@ std::unique_ptr<OrtTypeInfo> OrtTypeInfo::FromOrtValue(const OrtValue& value) {
     ORT_ENFORCE(tensor_data_type != nullptr, "OrtValue is TensorSequence type but has no element Tensor DataType.");
 
     TensorShape void_shape = {};
-    auto type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(void_shape, *tensor_data_type);
+    auto type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(void_shape, *tensor_data_type, false);
     auto type_info = MakePtr(ONNX_TYPE_TENSOR, std::move(type_shape));
     auto sequence_type_info = std::make_unique<OrtSequenceTypeInfo>(std::move(type_info));
     return MakePtr(std::move(sequence_type_info));
@@ -303,9 +303,9 @@ std::unique_ptr<OrtTypeInfo> OrtTypeInfo::FromTypeProto(const ONNX_NAMESPACE::Ty
               assert(false);
           }
         }
-        type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(std::move(shape_data), &dim_params, input);
+        type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(std::move(shape_data), &dim_params, input, true);
       } else {
-        type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(TensorShape(), nullptr, input);
+        type_shape = OrtTensorTypeAndShapeInfo::GetTensorShapeAndType(TensorShape(), nullptr, input, false);
       }
 
       result = MakePtr(ten_type, std::move(type_shape));

--- a/onnxruntime/core/framework/tensor_type_and_shape.cc
+++ b/onnxruntime/core/framework/tensor_type_and_shape.cc
@@ -102,6 +102,12 @@ ORT_API_STATUS_IMPL(OrtApis::GetSymbolicDimensions,
   return nullptr;
 }
 
+ORT_API_STATUS_IMPL(OrtApis::GetHasShape, _In_ const struct OrtTensorTypeAndShapeInfo* info,
+                    _Out_ bool* out) {
+  *out = info->has_shape;
+  return nullptr;
+}
+
 ORT_API_STATUS_IMPL(OrtApis::SetSymbolicDimensions,
                     _In_ struct OrtTensorTypeAndShapeInfo* info,
                     _In_ const char** names, _In_ size_t dim_params_length) {
@@ -228,6 +234,7 @@ std::unique_ptr<OrtTensorTypeAndShapeInfo> OrtTensorTypeAndShapeInfo::GetTensorS
 
   if (dim_params != nullptr) {
     type_and_shape->dim_params = *dim_params;
+    type_and_shape->has_shape = true;
   } else {
     type_and_shape->dim_params.resize(type_and_shape->shape.NumDimensions(), "");
   }

--- a/onnxruntime/core/framework/tensor_type_and_shape.h
+++ b/onnxruntime/core/framework/tensor_type_and_shape.h
@@ -24,6 +24,7 @@ struct OrtTensorTypeAndShapeInfo {
   // dim_param values. empty string if dim_value or no dim_param was specified.
   // one entry per dimension in shape. only guaranteed to be populated for graph inputs and outputs
   std::vector<std::string> dim_params;
+  bool has_shape = false;
 
   OrtTensorTypeAndShapeInfo();
   ~OrtTensorTypeAndShapeInfo();

--- a/onnxruntime/core/framework/tensor_type_and_shape.h
+++ b/onnxruntime/core/framework/tensor_type_and_shape.h
@@ -33,16 +33,19 @@ struct OrtTensorTypeAndShapeInfo {
   static std::unique_ptr<OrtTensorTypeAndShapeInfo> GetTensorShapeAndTypeHelper(
       ONNXTensorElementDataType type,
       onnxruntime::TensorShape shape,
-      const std::vector<std::string>* dim_params);
+      const std::vector<std::string>* dim_params,
+      bool has_shape);
 
   static std::unique_ptr<OrtTensorTypeAndShapeInfo> GetTensorShapeAndType(
       onnxruntime::TensorShape shape,
-      const onnxruntime::DataTypeImpl& tensor_data_type);
+      const onnxruntime::DataTypeImpl& tensor_data_type,
+      bool has_shape);
 
   static std::unique_ptr<OrtTensorTypeAndShapeInfo> GetTensorShapeAndType(
       onnxruntime::TensorShape shape,
       const std::vector<std::string>* dim_params,
-      const ONNX_NAMESPACE::TypeProto&);
+      const ONNX_NAMESPACE::TypeProto&,
+      bool has_shape);
 
   // We provide Clone() here to satisfy the existing coding pattern
   // as we need copies made on the heap even though we achieve that

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -80,7 +80,7 @@ struct OrtShapeInferContext {
       auto tensor_shape = ::onnxruntime::utils::GetTensorShapeFromTensorShapeProto(shape_proto);
       auto symbolic_dims = GetSymbolicDims(shape_proto);
       input_type_shapes_.emplace_back(
-          OrtTensorTypeAndShapeInfo::GetTensorShapeAndTypeHelper(elem_type, tensor_shape, &symbolic_dims, type_proto.has_shape()).release());
+          OrtTensorTypeAndShapeInfo::GetTensorShapeAndTypeHelper(elem_type, tensor_shape, &symbolic_dims, onnxruntime::utils::HasShape(type_proto)).release());
     }
   }
 

--- a/onnxruntime/core/session/custom_ops.cc
+++ b/onnxruntime/core/session/custom_ops.cc
@@ -80,7 +80,7 @@ struct OrtShapeInferContext {
       auto tensor_shape = ::onnxruntime::utils::GetTensorShapeFromTensorShapeProto(shape_proto);
       auto symbolic_dims = GetSymbolicDims(shape_proto);
       input_type_shapes_.emplace_back(
-          OrtTensorTypeAndShapeInfo::GetTensorShapeAndTypeHelper(elem_type, tensor_shape, &symbolic_dims).release());
+          OrtTensorTypeAndShapeInfo::GetTensorShapeAndTypeHelper(elem_type, tensor_shape, &symbolic_dims, type_proto.has_shape()).release());
     }
   }
 

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -4228,6 +4228,7 @@ static constexpr OrtApi ort_api_1_to_23 = {
     &OrtApis::Graph_GetModelMetadata,
     &OrtApis::GetModelCompatibilityForEpDevices,
     &OrtApis::CreateExternalInitializerInfo,
+    &OrtApis::GetHasShape,
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -150,6 +150,7 @@ ORT_API_STATUS_IMPL(GetDimensionsCount, _In_ const OrtTensorTypeAndShapeInfo* in
 ORT_API_STATUS_IMPL(GetDimensions, _In_ const OrtTensorTypeAndShapeInfo* info, _Out_ int64_t* dim_values, size_t dim_values_length);
 ORT_API_STATUS_IMPL(GetSymbolicDimensions, _In_ const OrtTensorTypeAndShapeInfo* info,
                     _Out_writes_all_(dim_params_length) const char* dim_params[], size_t dim_params_length);
+ORT_API_STATUS_IMPL(GetHasShape, _In_ const OrtTensorTypeAndShapeInfo* info, _Out_ bool* out);
 ORT_API_STATUS_IMPL(GetTensorShapeElementCount, _In_ const OrtTensorTypeAndShapeInfo* info, _Out_ size_t* out);
 ORT_API_STATUS_IMPL(GetTensorTypeAndShape, _In_ const OrtValue* value, _Outptr_ OrtTensorTypeAndShapeInfo** out);
 ORT_API_STATUS_IMPL(GetTypeInfo, _In_ const OrtValue* value, _Outptr_result_maybenull_ OrtTypeInfo** out);


### PR DESCRIPTION
### Description

The `OrtTensorTypeAndShapeInfo` struct lost the scalar information when converted from proto. The existing structure can't distinguish the `dynamic rank` and `scalar` cases. That makes the serialized graph lost shape area and the OV can't distinguish the scalar type.

Original tensor in prototxt:
``` 
   type {
      tensor_type {
        elem_type: 1
        shape {
        }
      }
    }
```
After serialized prototxt:
```
    type {
      tensor_type {
        elem_type: 1
      }
    }
```

- Add `has_shape` for `OrtTensorTypeAndShapeInfo`

#### Original Model
```
graph {
  name: "OpenVINOExecutionProvider_11295571201636618024_0"
  node {
    input: "absInput_1"
    output: "absOutput_0"
    name: "_0"
    op_type: "Abs"
    domain: ""
  }
  input {
    name: "absInput_1"
    type {
      tensor_type {
        elem_type: 1
        shape {
        }
      }
    }
  }
  output {
    name: "absOutput_0"
    type {
      tensor_type {
        elem_type: 1
        shape {
        }
      }
    }
  }
}
```
#### The graph after `OrtEpUtils::OrtGraphToProto`
```
graph {
  name: "OpenVINOExecutionProvider_11295571201636618024_0"
  node {
    input: "absInput_1"
    output: "absOutput_0"
    name: "_0"
    op_type: "Abs"
    domain: ""
  }
  input {
    name: "absInput_1"
    type {
      tensor_type {
        elem_type: 1
      }
    }
  }
  output {
    name: "absOutput_0"
    type {
      tensor_type {
        elem_type: 1
      }
    }
  }
}
```

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

- [CVS-173301](https://jira.devtools.intel.com/browse/CVS-173301)

