### PR TITLE
Enable Session Option to Stop Context Sharing 

### DIFF
--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -61,6 +61,15 @@ class SharedContext : public WeakSingleton<SharedContext> {
       size_t weights_size_;
     };
 
+    void clear() {
+      metadata.clear();
+      metadata_filepath.clear();
+      external_weight_filename.clear();
+      if (mapped_weights) {
+        delete mapped_weights.release();
+      }
+    }
+
     fs::path external_weight_filename;
     std::unique_ptr<WeightsFile> mapped_weights;
     Metadata::Map metadata;
@@ -68,7 +77,7 @@ class SharedContext : public WeakSingleton<SharedContext> {
   } shared_weights;
 
   void clear(){
-    shared_weights.metadata.clear();
+    shared_weights.clear();
   }
 };
 

--- a/onnxruntime/core/providers/openvino/contexts.h
+++ b/onnxruntime/core/providers/openvino/contexts.h
@@ -66,6 +66,10 @@ class SharedContext : public WeakSingleton<SharedContext> {
     Metadata::Map metadata;
     fs::path metadata_filepath;
   } shared_weights;
+
+  void clear(){
+    shared_weights.metadata.clear();
+  }
 };
 
 using config_t = std::map<std::string, ov::AnyMap>;
@@ -109,6 +113,7 @@ struct ProviderInfo {
   bool so_context_embed_mode{false};       // ORT session option
   bool so_share_ep_contexts{false};        // ORT session option
   fs::path so_context_file_path{};         // ORT session option
+  bool so_stop_share_ep_contexts{false};   // ORT session option
   const ConfigOptions* config_options{NULL};
   const std::unordered_set<std::string> valid_provider_keys = {"device_type", "device_id", "device_luid", "cache_dir", "precision",
                                                                "load_config", "context", "num_of_threads", "model_priority", "num_streams", "enable_opencl_throttling", "enable_qdq_optimizer",

--- a/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
+++ b/onnxruntime/core/providers/openvino/openvino_execution_provider.cc
@@ -65,6 +65,7 @@ OpenVINOExecutionProvider::~OpenVINOExecutionProvider() {
     backend_manager.ShutdownBackendManager();
   }
   backend_managers_.clear();
+  shared_context_.reset();
 }
 
 std::vector<std::unique_ptr<ComputeCapability>>
@@ -212,6 +213,10 @@ common::Status OpenVINOExecutionProvider::Compile(
     std::ofstream file{metadata_file_path, std::ios::binary};
     ORT_RETURN_IF_NOT(file, "Metadata file could not be written: ", metadata_file_path);
     file << metadata;
+  }
+
+  if (session_context_.so_stop_share_ep_contexts) {
+    shared_context_->clear();
   }
 
   return status;

--- a/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
+++ b/onnxruntime/core/providers/openvino/openvino_provider_factory.cc
@@ -28,6 +28,7 @@ void ParseConfigOptions(ProviderInfo& pi) {
   pi.so_context_embed_mode = pi.config_options->GetConfigOrDefault(kOrtSessionOptionEpContextEmbedMode, "0") == "1";
   pi.so_share_ep_contexts = pi.config_options->GetConfigOrDefault(kOrtSessionOptionShareEpContexts, "0") == "1";
   pi.so_context_file_path = pi.config_options->GetConfigOrDefault(kOrtSessionOptionEpContextFilePath, "");
+  pi.so_stop_share_ep_contexts = pi.config_options->GetConfigOrDefault(kOrtSessionOptionStopShareEpContexts, "0") == "1";
 
   if (pi.so_share_ep_contexts) {
     ov::AnyMap map;


### PR DESCRIPTION
This PR enables the session option: StopShareEpContexts ("**ep.stop_share_ep_contexts**" = 1/0), to explicitly clear the globally shared EP context after a session completes. This allows controlled cleanup of shared weights, metadata, its file path, and other cached artifacts stored in SharedContext.

For example, for model abc and model xyz:

model_abc(ep.share_ep_contexts=1, ep.stop_share_ep_contexts=1)
After this session, all existing shared context data is cleared.

model_xyz(ep.share_ep_contexts=1)
This model starts with a fresh shared context, without any leftover metadata or weights from model_abc.
