### PR TITLE
Fix Regression in Model PSS and PSR, add check for zero-size initializers

### DIFF
--- a/onnxruntime/core/providers/openvino/backend_manager.cc
+++ b/onnxruntime/core/providers/openvino/backend_manager.cc
@@ -676,7 +676,7 @@ BackendManager::GetModelProtoFromFusedNode(const onnxruntime::Node& fused_node,
           if (src_init->raw_data().size() > 0)
               SetExternalDataFields(proto_init, src_init->raw_data().data(), src_init->raw_data().size());
           else
-              LOGS(logger, VERBOSE) << "Initializer has empty raw_data: skipping...";
+              LOGS(logger, VERBOSE) << "Initializer has empty raw_data: skipping initializer '" << src_init->name() << "'...";
         } else if (onnxruntime::utils::HasExternalDataInMemory(*src_init)) {
           auto it_ext = external_initializers_offset_and_length.find(name);
           if (it_ext == external_initializers_offset_and_length.end()) {


### PR DESCRIPTION
### Description
In https://github.com/intel/onnxruntime/pull/817 we assumed that initializers's size is larger than zero. This is not the case for some models. While Initializers with RAW data usually works, as OV can skip them, there was an issue when we converted those initializers with RAW data to initializers with EXT data in memory.
So it's safe to add this check on the OVEP side (later we'll try to improve OpenVino side as well, and double check with their implementation)

### Motivation and Context
CVS-174653


