### PR TITLE
CVS-175447-[OVEP] Add a check for type mismatches in QDQ stripping

### DIFF
--- a/onnxruntime/core/providers/openvino/qdq_transformations/qdq_scales_fix.cpp
+++ b/onnxruntime/core/providers/openvino/qdq_transformations/qdq_scales_fix.cpp
@@ -470,6 +470,7 @@ struct CustomGraph {
           InlinedVector<NodeArg*> output_args = {&output};
           Node& cast_node = original_graph.AddNode(cast_node_name, "Cast", "", input_args, output_args, nullptr, "");
           auto type_str = dq_node_ref.OutputDefs()[0]->Type();
+          ORT_ENFORCE(type_str != nullptr, "Type string is null in QDQ scales fix.");
           auto type_cast = type_str->find("tensor(float)") != std::string::npos ? onnx::TensorProto_DataType_FLOAT : onnx::TensorProto_DataType_FLOAT16;
           ORT_ENFORCE((type_cast == onnx::TensorProto_DataType_FLOAT) || (type_str->find("tensor(float16)") != std::string::npos),
               "QDQ type misalignment, expected float32 or float16 output");


### PR DESCRIPTION
### Description
When rewiring the graph after eliminating QDQ pairs, the runtime now checks whether the type matches before and after the eliminated nodes and inserts a Cast node if there is a mismatch.

### Motivation and Context
At present, QDQ elimination assumes the floating point type is the same before the QuantizeLinear node and after the following DequantizeLinear, producing errors if the types mismatch.

### If feature goes to new ABI?
Yes

### Jira Ticket :
[CVS-175447](https://jira.devtools.intel.com/browse/CVS-175447)

