### PR TITLE
Update CI to use OpenVINO 2025.4.0

### DIFF
--- a/.github/workflows/windows_openvino.yml
+++ b/.github/workflows/windows_openvino.yml
@@ -47,12 +47,12 @@ jobs:
         with:
           architecture: x64
 
-      - name: Download OpenVINO Toolkit v2025.2.0
+      - name: Download OpenVINO Toolkit v2025.4.0
         env:
-          OpenVINOVersion: 2025.2.0
+          OpenVINOVersion: 2025.4.0
         shell: pwsh
         run: |
-          $Url ="https://storage.openvinotoolkit.org/repositories/openvino/packages/2025.2/windows/openvino_toolkit_windows_2025.2.0.19140.c01cd93e24d_x86_64.zip"
+          $Url ="https://storage.openvinotoolkit.org/repositories/openvino/packages/pre-release/2025.4.0rc2/windows/openvino_toolkit_windows_2025.4.0.dev20251113_x86_64.zip"
           $OutputPath = "$env:RUNNER_TEMP\openvino.zip"
           $ExtractPath = "$env:RUNNER_TEMP\openvino-v$env:OpenVINOVersion"
           $TempExtractPath = "$env:RUNNER_TEMP\openvino_temp"
@@ -95,7 +95,7 @@ jobs:
         shell: pwsh
         # Use $GITHUB_ENV to set the variable for subsequent steps
         run: |
-          $openVinoRootDir = Join-Path $env:RUNNER_TEMP "openvino-v2025.2.0"
+          $openVinoRootDir = Join-Path $env:RUNNER_TEMP "openvino-v2025.4.0"
           echo "OpenVINORootDir=$openVinoRootDir" >> $env:GITHUB_ENV
 
       - name: Print OpenVINORootDir after downloading OpenVINO

--- a/tools/ci_build/github/linux/docker/inference/x86_64/python/openvino/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/python/openvino/Dockerfile
@@ -19,8 +19,8 @@ RUN dnf install -y --nodocs \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
-ENV INTEL_OPENVINO_DIR=/opt/intel/openvino_2025.2.0
-ARG OPENVINO_PACKAGE_URL=https://storage.openvinotoolkit.org/repositories/openvino/packages/2025.2/linux/openvino_toolkit_rhel8_2025.2.0.19140.c01cd93e24d_x86_64.tgz
+ENV INTEL_OPENVINO_DIR=/opt/intel/openvino_2025.4.0
+ARG OPENVINO_PACKAGE_URL=https://storage.openvinotoolkit.org/repositories/openvino/packages/pre-release/2025.4.0rc2/linux/openvino_toolkit_rhel8_2025.4.0.dev20251113_x86_64.tgz
 ARG TEMP_DIR=/tmp/openvino_installer
 
 RUN mkdir -p ${TEMP_DIR} && \


### PR DESCRIPTION
### Summary
Updates CI/CD pipelines to download and use OpenVINO 2025.4.0 pre-release build.

### Changes
- Updated Windows workflow to download OpenVINO 2025.4.0.dev20251113
- Updated Linux Docker image to use OpenVINO 2025.4.0.dev20251113
- Modified download URLs to point to pre-release packages