### PR TITLE
skipped failing testcase (MathOpTest.Clip_Default_int64)

### DIFF
--- a/onnxruntime/test/providers/cpu/math/clip_test.cc
+++ b/onnxruntime/test/providers/cpu/math/clip_test.cc
@@ -86,10 +86,6 @@ TEST(MathOpTest, Clip_Default_int64) {
     GTEST_SKIP() << "Skipping because of the following error: Expected equality of these values: 11 and -9223372036854775808";
   }
 
-  if (DefaultOpenVINOExecutionProvider().get() != nullptr) {
-    GTEST_SKIP() << "Skipping because of the following error: error: Expected equality of these values: cur_expected[i] Which is: 11 cur_actual[i] Which is: 0";
-  }
-
   OpTester test("Clip", 12);
 
   std::vector<int64_t> dims{3, 3};
@@ -103,7 +99,8 @@ TEST(MathOpTest, Clip_Default_int64) {
                            -5, 9, 82});
 
   // TensorRT does not support Clip opset 12 yet.
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+  // Skipping for OpenVINO because of the following error: Expected equality of these values: cur_expected[i] Which is: 11 cur_actual[i] Which is: 0
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(MathOpTest, Clip_Default_uint64) {


### PR DESCRIPTION
Test Case is temporarily skipped until the issue is fixed in Openvino [CVS-176933].

