### PR TITLE
Support of OV version for resize op

### DIFF
--- a/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
+++ b/onnxruntime/core/providers/openvino/ov_versions/data_ops.cc
@@ -491,7 +491,8 @@ void DataOps::populate_op_mode_supported() {
   }
   {
     UnsupportedOpMode obj = {{V_2023_1, V_2023_2, V_2023_3, V_2024_0, V_2024_1, V_2024_2,
-                              V_2024_3, V_2024_4, V_2024_5, V_2024_6, V_2025_0, V_2025_1, V_2025_2, V_2025_3, V_2025_4},
+                              V_2024_3, V_2024_4, V_2024_5, V_2024_6, V_2025_0, V_2025_1,
+                              V_2025_2, V_2025_3, V_2025_4, V_2026_0, V_2026_1},
                              [this](const Node* node, const InitializedTensorSet&) {
                                auto& attributes = node->GetAttributes();
                                if (attributes.count("coordinate_transformation_mode") > 0) {

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -1450,7 +1450,7 @@ void QuantizeLinearOp19Test(bool saturate) {
     y.push_back(OutT(it, saturate));
   }
   test.AddOutput<OutT>("y", dims, y);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(QuantizeLinearOpTest, Float8) {
@@ -1492,7 +1492,7 @@ void QuantizeLinearOp19F16Test(bool saturate) {
     y.push_back(OutT(it, saturate));
   }
   test.AddOutput<OutT>("y", dims, y);
-  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
 }
 
 TEST(QuantizeLinearOpMLFloat16Test, Float8) {


### PR DESCRIPTION
On enabling Float8 precision, the Quantize Linear Operator Test fails with accuracy issues. The PR disables the test for Float8 precision specifically and also add the support for 2026.1 for resize op


