### PR TITLE
EISW-212077 Fix for Model GT and GTC inference latency issue

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -74,7 +74,9 @@ RunTiming OnnxRuntimeTestSession::Run() {
     // For outputs with data-dependent shapes (e.g. NonZero), the shape changes
     // between runs. ORT caches the allocated tensor and fails shape verification
     // on the next run. Reset all outputs so ORT always allocates fresh buffers.
-    for (auto& output : outputs_) output = Ort::Value(nullptr);
+    if (has_dynamic_outputs_) {
+      for (auto& output : outputs_) output = Ort::Value(nullptr);
+    }
     session_.Run(run_options, input_names_.data(), input.data(), input_names_.size(),
                  output_names_raw_ptr.data(), outputs_.data(), output_names_raw_ptr.size());
     timing.submit_timing = std::chrono::high_resolution_clock::now() - start;
@@ -939,6 +941,9 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
     auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
     std::vector<int64_t> output_shape = tensor_info.GetShape();
     auto is_dynamic = std::find(output_shape.begin(), output_shape.end(), -1) != output_shape.end();
+    if (is_dynamic) {
+      has_dynamic_outputs_ = true;
+    }
     if (is_dynamic || device_memory_name_.empty()) {
       outputs_.emplace_back(Ort::Value(nullptr));
     } else {

--- a/onnxruntime/test/perftest/ort_test_session.h
+++ b/onnxruntime/test/perftest/ort_test_session.h
@@ -49,6 +49,7 @@ class OnnxRuntimeTestSession : public TestSession {
   Ort::UnownedAllocator allocator_{default_allocator_};
   std::vector<std::vector<Ort::Value>> test_inputs_;
   std::vector<Ort::Value> outputs_;
+  bool has_dynamic_outputs_{false};
   std::vector<std::string> output_names_;
   // The same size with output_names_.
   // TODO: implement a customized allocator, then we can remove output_names_ to simplify this code


### PR DESCRIPTION
added check to see if model is dynamic before resetting ORT buffers for every run which caused increase in inference latency